### PR TITLE
add new 2021 logo

### DIFF
--- a/artwork.json
+++ b/artwork.json
@@ -244,5 +244,19 @@
       "web": "https://pbu.cl/"
     },
     "license": "MIT"
+  },
+  {
+    "date": "2021-08-26",
+    "image": "/logo.svg",
+    "title": "New Deno logo",
+    "alt": "The new official logo of Deno",
+    "artist": {
+      "name": "hashrock",
+      "profile_image": "https://avatars0.githubusercontent.com/u/3132889",
+      "twitter": "hashedrock",
+      "github": "hashrock",
+      "web": "https://hashrock.studio.design/"
+    },
+    "license": "UNKNOWN"
   }
 ]


### PR DESCRIPTION
I don't know the actual creation date and didn't want to assume the license so I added "UNKNOWN" there and made this a draft PR for now. @hashrock might have to look over this.

Also the logo referenced here is actually the SVG version created by @jaydenseric here: https://github.com/denoland/dotland/pull/1836. Don't know if they should be added to this JSON as well.

Sorry for pinging you guys and I hope I did everything correctly. 😶‍🌫️