### PR TITLE
fix: handle connection closed error

### DIFF
--- a/worker/main.ts
+++ b/worker/main.ts
@@ -4,6 +4,10 @@ import { handleRequest, withLog } from "./handler.ts";
 
 const handler = withLog(handleRequest);
 
-addEventListener("fetch", (event: FetchEvent) => {
-  event.respondWith(handler(event.request));
+addEventListener("fetch", async (event: FetchEvent) => {
+  try {
+    await event.respondWith(handler(event.request));
+  } catch (e) {
+    console.log(e);
+  }
 });


### PR DESCRIPTION
`respondWith` returns a promise (though [typed as void](https://deno.land/x/deploy@0.4.0/types/deploy.fetchevent.d.ts#L10)), and that promise is rejected when the client closed the connection before response finished. And because we don't handle that rejection, that situation causes the crash of the isolate.