### PR TITLE
fix: substitute correct std version to $STD_VERSION

### DIFF
--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -23,6 +23,7 @@ import {
   getVersionDeps,
   listExternalDependencies,
   getBasePath,
+  parseQuery,
 } from "../util/registry_utils";
 import Header from "./Header";
 import Footer from "./Footer";
@@ -46,14 +47,12 @@ function Registry(): React.ReactElement {
   const [readme, setReadme] = useState<string | null | undefined>();
 
   // Name, version and path
-  const { query, asPath, push, replace } = useRouter();
-  const isStd = asPath.startsWith("/std");
+  const { query, push, replace } = useRouter();
   const { name, version, path } = useMemo(() => {
-    const [identifier, ...pathParts] = (query.rest as string[]) ?? [];
-    const path = pathParts.length === 0 ? "" : `/${pathParts.join("/")}`;
-    const [name, version] = parseNameVersion(identifier ?? "");
-    return { name, version, path };
+    return parseQuery(query.rest as string[]);
   }, [query]);
+  const isStd = name === "std";
+  const stdVersion = isStd ? version || versions?.latest : undefined;
   function gotoVersion(newVersion: string, doReplace?: boolean) {
     const href = `${!isStd ? "/x" : ""}/[...rest]`;
     const asPath = `${getBasePath({
@@ -432,9 +431,7 @@ function Registry(): React.ReactElement {
                                 sourceURL={readmeURL}
                                 repositoryURL={readmeRepositoryURL}
                                 baseURL={basePath}
-                                stdVersion={
-                                  isStd ? versions?.latest : undefined
-                                }
+                                stdVersion={stdVersion}
                               />
                             ) : null}
                           </div>

--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -6,7 +6,6 @@ import Link from "next/link";
 import Head from "next/head";
 import twas from "twas";
 import {
-  parseNameVersion,
   denoDocAvailableForURL,
   isReadme,
   getSourceURL,

--- a/util/registry_utils.test.ts
+++ b/util/registry_utils.test.ts
@@ -13,6 +13,8 @@ import {
   findRootReadme,
   isReadme,
   fileTypeFromURL,
+  parseNameVersion,
+  parseQuery,
 } from "./registry_utils";
 import "isomorphic-unfetch";
 
@@ -214,4 +216,25 @@ test("isReadme", () => {
   for (const [path, expectedToBeReadme] of tests) {
     expect([path, isReadme(path)]).toEqual([path, expectedToBeReadme]);
   }
+});
+
+test("parseNameVersion", () => {
+  expect(parseNameVersion("ms@v0.1.0")).toEqual(["ms", "v0.1.0"]);
+  expect(parseNameVersion("xstate@xstate@4.25.0")).toEqual([
+    "xstate",
+    "xstate@4.25.0",
+  ]);
+});
+
+test("parseQuery", () => {
+  expect(parseQuery(["std@0.101.0", "http", "server.ts"])).toEqual({
+    name: "std",
+    version: "0.101.0",
+    path: "/http/server.ts",
+  });
+  expect(parseQuery(["oak@v9.0.1", "mod.ts"])).toEqual({
+    name: "oak",
+    version: "v9.0.1",
+    path: "/mod.ts",
+  });
 });

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -270,6 +270,15 @@ export function parseNameVersion(nameVersion: string): [string, string] {
   return [name, version.join("@")];
 }
 
+export function parseQuery(
+  queryRest: string[]
+): { name: string; version: string; path: string } {
+  const [identifier, ...pathParts] = (queryRest as string[]) ?? [];
+  const path = pathParts.length === 0 ? "" : `/${pathParts.join("/")}`;
+  const [name, version] = parseNameVersion(identifier ?? "");
+  return { name, version, path };
+}
+
 const markdownExtension = "(?:markdown|mdown|mkdn|mdwn|mkd|md)";
 const orgExtension = "org";
 const readmeBaseRegex = `readme(?:\\.(${markdownExtension}|${orgExtension}))?`;


### PR DESCRIPTION
Fixes #1787

This PR fixes the substitution of $STD_VERSION in registry rendering.

This PR also adds test cases of path parsing utilities of registry.