### PR TITLE
fix: substitute $STD_VERSION in README.md page

### DIFF
--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -444,6 +444,7 @@ function Registry(): React.ReactElement {
                                   repositoryURL={repositoryURL}
                                   documentationURL={documentationURL}
                                   baseURL={basePath}
+                                  stdVersion={stdVersion}
                                 />
                               )
                               : null}


### PR DESCRIPTION
This PR adds the substitution of `$STD_VERSION` meta parameter in `.../README.md` urls (ex. https://deno.land/std@0.99.0/ws/README.md )

<img width="1311" alt="スクリーンショット 2021-09-28 13 19 12" src="https://user-images.githubusercontent.com/613956/135022770-28997f48-a143-485b-832a-6b9756d6ab56.png">

closes #1788 