### PR TITLE
fix: correct handling of already encoded image urls

### DIFF
--- a/components/Markup.tsx
+++ b/components/Markup.tsx
@@ -108,6 +108,6 @@ export function transformImageUri(sourceURL: string) {
     if (isRelative(uri)) {
       return relativeToAbsolute(sourceURL, uri);
     }
-    return encodeURI(uri);
+    return encodeURI(decodeURI(uri));
   };
 }


### PR DESCRIPTION
This PR fixes the handling of image URLs in markdown. When the urls are already url encoded, now the registry renderer encodes them again. Now this PR prevents that double encoding by decoding them first.

This PR fixes the badges of bdfparse https://deno.land/x/bdfparser@v2.2.5

Before
<img width="943" alt="スクリーンショット 2021-09-28 13 31 28" src="https://user-images.githubusercontent.com/613956/135023643-cb207bc2-e6f8-4309-9a49-01db92cd2c4b.png">

After
<img width="936" alt="スクリーンショット 2021-09-28 13 31 38" src="https://user-images.githubusercontent.com/613956/135023637-b08137bd-6bbb-4c64-909d-0295909a75c7.png">


closes #1881