### PR TITLE
chore: update references and links to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# deno_website2
+# dotland
 
-[![Build Status](https://github.com/denoland/deno_website2/workflows/ci/badge.svg?branch=main&event=push)](https://github.com/denoland/deno_website2/actions)
+[![Build Status](https://github.com/denoland/dotland/workflows/ci/badge.svg?branch=main&event=push)](https://github.com/denoland/dotland/actions)
 
 This is the code for https://deno.land/
 

--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -7,7 +7,7 @@ import { useLayoutEffect } from "react";
 
 // Modifies the color of 'variable' token
 // to avoid poor contrast
-// ref: https://github.com/denoland/deno_website2/issues/1724
+// ref: https://github.com/denoland/dotland/issues/1724
 for (const style of light.styles) {
   if (style.types.includes("variable")) {
     // Chrome suggests this color instead of rgb(156, 220, 254);

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -168,11 +168,11 @@ function Footer(props: { simple?: boolean }): React.ReactElement {
               src="https://img.shields.io/github/workflow/status/denoland/deno_doc/ci/main?label=deno_doc&logo=github"
             />
           </a>
-          <a href="https://github.com/denoland/deno_website2">
+          <a href="https://github.com/denoland/dotland">
             <img
               className="m-2 opacity-75"
-              alt="denoland/deno_website2 CI"
-              src="https://img.shields.io/github/workflow/status/denoland/deno_website2/ci/main?label=deno_website2&logo=github"
+              alt="denoland/dotland CI"
+              src="https://img.shields.io/github/workflow/status/denoland/dotland/ci/main?label=dotland&logo=github"
             />
           </a>
         </div>

--- a/components/Markup.tsx
+++ b/components/Markup.tsx
@@ -81,7 +81,7 @@ export function transformLinkUri(displayURL: string, baseURL: string) {
 
     // If the URL is relative, it should be relative to the canonical URL of the file.
     if (isRelative(href)) {
-      // https://github.com/denoland/deno_website2/issues/1047
+      // https://github.com/denoland/dotland/issues/1047
       href = decodeURIComponent(relativeToAbsolute(displayURL, href));
     }
     if (href.startsWith("/") && !href.startsWith("//")) {

--- a/components/app.css
+++ b/components/app.css
@@ -16,7 +16,7 @@ html {
   outline: none;
 }
 
-/* https://github.com/denoland/deno_website2/issues/1163 */
+/* https://github.com/denoland/dotland/issues/1163 */
 .language-toml > code > .token-line > .table {
   display: inline;
 }

--- a/pages/artwork.tsx
+++ b/pages/artwork.tsx
@@ -22,7 +22,7 @@ function ArtworkPage(): React.ReactElement {
           <p className="mt-4 text-lg">
             Do you have a piece to display here?{" "}
             <a
-              href="https://github.com/denoland/deno_website2/blob/main/artwork.json"
+              href="https://github.com/denoland/dotland/blob/main/artwork.json"
               className="link"
             >
               Add it!

--- a/pages/translations.tsx
+++ b/pages/translations.tsx
@@ -23,7 +23,7 @@ function TranslationsPage(): React.ReactElement {
             Deno docs is available in the following languages. Do you have a
             piece to display here?{" "}
             <a
-              href="https://github.com/denoland/deno_website2/blob/main/translations.json"
+              href="https://github.com/denoland/dotland/blob/main/translations.json"
               className="link"
             >
               Add it!

--- a/pages/x/index.tsx
+++ b/pages/x/index.tsx
@@ -645,7 +645,7 @@ function ThirdPartyRegistryList(): React.ReactElement {
                       the latest version of a module (when you do not explicitly
                       specify a version). This is because it can{" "}
                       <a
-                        href="https://github.com/denoland/deno_website2/issues/997"
+                        href="https://github.com/denoland/dotland/issues/997"
                         className="link"
                       >
                         be unsafe to not tag dependencies


### PR DESCRIPTION
The repo was recently renamed from `deno_website2` to `dotland`, this updates some references across the files.

I've updated:

- the title and the CI badge in the readme
- the CI badge in the footer
- all the references to issues in the repo (the old links still work, but I think it's nicer to have the correct git url)
- the links to submit new artwork and translations

I've not touched:

- the project name in the `package.json` (I am not sure that would break anything?)
- the links to translations, as they're on forks
