### PR TITLE
Cache proxied requests to now.sh in memory

### DIFF
--- a/worker/handler.ts
+++ b/worker/handler.ts
@@ -165,7 +165,7 @@ async function proxyFile(
     return new Response(body, {
       headers: {
         "content-type": cacheEntry.contentType,
-        "cache-control": cacheEntry.immutable ? "public,immutable" : "private",
+        "cache-control": cacheEntry.immutable ? "public,max-age=31536000,immutable" : "public,max-age=0,must-revalidate",
         "etag": cacheEntry.etag,
       },
     });

--- a/worker/handler.ts
+++ b/worker/handler.ts
@@ -108,6 +108,12 @@ interface CacheEntry {
 
 const cache = new Map<string, CacheEntry>();
 
+// When deploying a new version, the worker will be updated before the static
+// website hosted by Vercel gets updated. Therefore we clear the cache 2 minutes
+// after startup up to ensure that there is no stale static content in the
+// in-memory cache.
+setTimeout(() => cache.clear(), 2 * 60 * 1000);
+
 async function proxyFile(
   url: URL,
   remoteUrl: string,

--- a/worker/handler.ts
+++ b/worker/handler.ts
@@ -165,7 +165,9 @@ async function proxyFile(
     return new Response(body, {
       headers: {
         "content-type": cacheEntry.contentType,
-        "cache-control": cacheEntry.immutable ? "public,max-age=31536000,immutable" : "public,max-age=0,must-revalidate",
+        "cache-control": cacheEntry.immutable
+          ? "public,max-age=31536000,immutable"
+          : "public,max-age=0,must-revalidate",
         "etag": cacheEntry.etag,
       },
     });


### PR DESCRIPTION
Hopefully this would reduce deno.land downtime.
All static assets combined currently take up about ~30mb so the lack of cache eviction should not cause any immediate problems.
Nonetheless, this is a POC, feel free to criticize.