### PR TITLE
Add `/install.{sh,ps1}` URL aliases

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,6 +1,0 @@
-{
-  "trailingSlash": false,
-  "github": {
-    "silent": true
-  }
-}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -261,7 +261,7 @@ const InstallSection = () => {
       <p className="py-2">Shell (Mac, Linux):</p>
       <CodeBlock
         language="bash"
-        code={`curl -fsSL https://deno.land/x/install/install.sh | sh`}
+        code={`curl -fsSL https://deno.land/install.sh | sh`}
       />
     </div>
   );
@@ -281,7 +281,7 @@ const InstallSection = () => {
       <p className="mb-2">PowerShell (Windows):</p>
       <CodeBlock
         language="bash"
-        code={`iwr https://deno.land/x/install/install.ps1 -useb | iex`}
+        code={`iwr https://deno.land/install.ps1 -useb | iex`}
       />
     </div>
   );

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,12 @@
   "trailingSlash": false,
   "redirects": [
     {
-      "source": "/install",
+      "source": "/install.sh",
       "destination": "/x/install/install.sh"
+    },
+    {
+      "source": "/install.ps1",
+      "destination": "/x/install/install.ps1"
     }
   ],
   "github": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "trailingSlash": false,
+  "redirects": [
+    {
+      "source": "/install",
+      "destination": "/x/install/install.sh"
+    }
+  ],
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
Fix #1961

Added `/install.sh -> /x/install/install.sh` and `/install.ps1 -> /x/install/install.ps1` aliases.

Also renamed the [deprecated](https://vercel.link/combining-old-and-new-config) `now.json` to `vercel.json`.