### PR TITLE
Add URL aliases to installation scripts

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -261,7 +261,7 @@ const InstallSection = () => {
       <p className="py-2">Shell (Mac, Linux):</p>
       <CodeBlock
         language="bash"
-        code={`curl -fsSL https://deno.land/x/install/install.sh | sh`}
+        code={`curl -fsSL https://deno.land/install.sh | sh`}
       />
     </div>
   );
@@ -281,7 +281,7 @@ const InstallSection = () => {
       <p className="mb-2">PowerShell (Windows):</p>
       <CodeBlock
         language="bash"
-        code={`iwr https://deno.land/x/install/install.ps1 -useb | iex`}
+        code={`iwr https://deno.land/install.ps1 -useb | iex`}
       />
     </div>
   );

--- a/worker/handler.ts
+++ b/worker/handler.ts
@@ -65,6 +65,10 @@ export async function handleRequest(request: Request): Promise<Response> {
     return handleVSCRequest(url);
   }
 
+  if (["/install.sh", "/install.ps1"].includes(url.pathname)) {
+    return Response.redirect(`/x/install${url.pathname}`, 307);
+  }
+
   const isRegistryRequest = url.pathname.startsWith("/std") ||
     url.pathname.startsWith("/x/");
 

--- a/worker/handler.ts
+++ b/worker/handler.ts
@@ -66,7 +66,7 @@ export async function handleRequest(request: Request): Promise<Response> {
   }
 
   if (["/install.sh", "/install.ps1"].includes(url.pathname)) {
-    return Response.redirect(`/x/install${url.pathname}`, 307);
+    return Response.redirect(`https://deno.land/x/install${url.pathname}`, 307);
   }
 
   const isRegistryRequest = url.pathname.startsWith("/std") ||

--- a/worker/handler_test.ts
+++ b/worker/handler_test.ts
@@ -175,6 +175,17 @@ Deno.test({
 });
 
 Deno.test({
+  name: "/install.sh responds with /x/install/install.sh redirect",
+  async fn() {
+    const result = await handleRequest(new Request("https://deno.land/install.sh"));
+    assertEquals(result.status, 307);
+    assert(result.headers.get("Location")?.includes(
+      "/x/install/install.sh",
+    ));
+  },
+});
+
+Deno.test({
   name: "extractAltLineNumberReference",
   fn() {
     type TestCase = {

--- a/worker/handler_test.ts
+++ b/worker/handler_test.ts
@@ -177,7 +177,9 @@ Deno.test({
 Deno.test({
   name: "/install.sh responds with /x/install/install.sh redirect",
   async fn() {
-    const result = await handleRequest(new Request("https://deno.land/install.sh"));
+    const result = await handleRequest(
+      new Request("https://deno.land/install.sh"),
+    );
     assertEquals(result.status, 307);
     assert(result.headers.get("Location")?.includes(
       "/x/install/install.sh",


### PR DESCRIPTION
This is another attempt of #1969. I don't have any means to test it but it should work properly.

Closes https://github.com/denoland/dotland/issues/1961