### PR TITLE
feat: add support for v2 registry suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the code for https://deno.land/
 
 This website consists of two parts
 
-1. A Cloudflare Worker
+1. A Deploy worker
 2. A Next.js app hosted on Vercel
 
 We want to provide pretty and semantic URLs for modules that will be used within

--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -80,7 +80,7 @@ function Registry(): React.ReactElement {
     path,
   ]);
   const documentationURL = useMemo(() => {
-    const doc = `https://doc.deno.land/https/deno.land${canonicalPath}`;
+    const doc = `https://doc.deno.land/https://deno.land${canonicalPath}`;
     return denoDocAvailableForURL(canonicalPath) ? doc : null;
   }, [canonicalPath]);
 

--- a/worker/handler.ts
+++ b/worker/handler.ts
@@ -1,9 +1,13 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
-import { handleRegistryRequest } from "./registry.ts";
-import { handleVSCRequest } from "./vscode.ts";
 import { reportAnalytics } from "./analytics.ts";
-import { ConnInfo } from "https://deno.land/std@0.112.0/http/server.ts";
+import { handleRegistryRequest } from "./registry.ts";
+import { handleConfigRequest } from "./registry_config.ts";
+import { handleApiRequest } from "./suggestions.ts";
+import { handleVSCRequest } from "./vscode.ts";
+
+import type { ConnInfo } from "https://deno.land/std@0.112.0/http/server.ts";
+import { accepts } from "https://deno.land/x/oak_commons@0.1.1/negotiation.ts";
 
 const REMOTE_URL = "https://deno-website2.now.sh";
 
@@ -36,37 +40,50 @@ export function withLog(
   };
 }
 
-export async function handleRequest(request: Request): Promise<Response> {
-  const accept = request.headers.get("accept");
-  const isHtml = accept && accept.indexOf("html") >= 0;
+export function handleRequest(request: Request): Promise<Response> {
+  const isHtml = request.headers.has("accept") && accepts(request, "text/html");
 
   const url = new URL(request.url);
 
   if (url.pathname === "/v1") {
-    return Response.redirect("https://deno.land/posts/v1", 301);
-  }
-
-  if (url.pathname === "/posts") {
-    return Response.redirect("https://deno.com/blog", 307);
-  }
-
-  if (url.pathname.startsWith("/posts/")) {
-    return Response.redirect(
-      `https://deno.com/blog/${url.pathname.substring("/posts/".length)}`,
-      307,
+    return Promise.resolve(
+      Response.redirect("https://deno.land/posts/v1", 301),
     );
   }
 
+  if (url.pathname === "/posts") {
+    return Promise.resolve(Response.redirect("https://deno.com/blog", 307));
+  }
+
+  if (url.pathname.startsWith("/posts/")) {
+    return Promise.resolve(Response.redirect(
+      `https://deno.com/blog/${url.pathname.substring("/posts/".length)}`,
+      307,
+    ));
+  }
+
   if (url.pathname.startsWith("/typedoc")) {
-    return Response.redirect("https://doc.deno.land/builtin/stable", 301);
+    return Promise.resolve(
+      Response.redirect("https://doc.deno.land/deno/stable", 301),
+    );
   }
 
   if (url.pathname.startsWith("/_vsc")) {
     return handleVSCRequest(url);
   }
 
+  if (url.pathname.startsWith("/_api/")) {
+    return handleApiRequest(url);
+  }
+
   if (["/install.sh", "/install.ps1"].includes(url.pathname)) {
-    return Response.redirect(`https://deno.land/x/install${url.pathname}`, 307);
+    return Promise.resolve(
+      Response.redirect(`https://deno.land/x/install${url.pathname}`, 307),
+    );
+  }
+
+  if (url.pathname === "/.well-known/deno-import-intellisense.json") {
+    return handleConfigRequest(request);
   }
 
   const isRegistryRequest = url.pathname.startsWith("/std") ||
@@ -76,7 +93,9 @@ export async function handleRequest(request: Request): Promise<Response> {
     if (isHtml) {
       const ln = extractAltLineNumberReference(url.toString());
       if (ln) {
-        return Response.redirect(ln.rest + "#L" + ln.line, 302);
+        return Promise.resolve(
+          Response.redirect(`${ln.rest}#L${ln.line}`, 302),
+        );
       }
     } else {
       return handleRegistryRequest(url);
@@ -84,7 +103,7 @@ export async function handleRequest(request: Request): Promise<Response> {
   }
 
   if (!["HEAD", "GET"].includes(request.method)) {
-    return new Response(null, { status: 405 }); // Method not allowed.
+    return Promise.resolve(new Response(null, { status: 405 })); // Method not allowed.
   }
 
   return proxyFile(url, REMOTE_URL, request);

--- a/worker/main.ts
+++ b/worker/main.ts
@@ -6,5 +6,5 @@ import { listenAndServe } from "https://deno.land/std@0.108.0/http/server.ts";
 
 const handler = withLog(handleRequest);
 
-console.log("The server is available at http://localhost:8080");
+console.log("The server is available at http://localhost:8081");
 listenAndServe(":8081", handler);

--- a/worker/main.ts
+++ b/worker/main.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env -S deno run --allow-read=. --allow-net --allow-env
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
 import { handleRequest, withLog } from "./handler.ts";
@@ -6,4 +7,4 @@ import { listenAndServe } from "https://deno.land/std@0.108.0/http/server.ts";
 const handler = withLog(handleRequest);
 
 console.log("The server is available at http://localhost:8080");
-listenAndServe(":8080", handler);
+listenAndServe(":8081", handler);

--- a/worker/registry.ts
+++ b/worker/registry.ts
@@ -5,6 +5,8 @@ import { parseNameVersion } from "../util/registry_utils.ts";
 export const S3_BUCKET =
   "http://deno-registry2-prod-storagebucket-b3a31d16.s3-website-us-east-1.amazonaws.com/";
 
+/** Handle _legacy_ v1 registry requests.  v2 is handled by `./suggestions.ts`.
+ */
 export async function handleRegistryRequest(url: URL): Promise<Response> {
   const entry = parsePathname(url.pathname);
   if (!entry) {

--- a/worker/registry_config.ts
+++ b/worker/registry_config.ts
@@ -1,0 +1,175 @@
+/* Copyright 2021 the Deno authors. All rights reserved. MIT license. */
+
+import { accepts } from "https://deno.land/x/oak_commons@0.1.1/negotiation.ts";
+
+interface RegistryDefVariable {
+  key: string;
+  documentation?: string;
+  url: string;
+}
+
+interface RegistryDef {
+  schema: string;
+  variables: RegistryDefVariable[];
+}
+
+interface RegistryConfig {
+  version: 1 | 2;
+  registries: RegistryDef[];
+}
+
+const MAX_AGE_1_DAY = "max-age=86400";
+
+/** The _legacy_ v1 configuration file. This will be provided to any client
+ * which does not indicate it is capable of understanding the v2 registry
+ * (earlier than Deno 1.17.1) */
+const configV1: RegistryConfig = {
+  version: 1,
+  registries: [
+    {
+      schema: "/x/:module([a-z0-9_]*)@:version?/:path*",
+      variables: [
+        {
+          key: "module",
+          url: "https://api.deno.land/modules?simple=1",
+        },
+        {
+          key: "version",
+          url: "https://deno.land/_vsc1/modules/${module}",
+        },
+        {
+          key: "path",
+          url: "https://deno.land/_vsc1/modules/${module}/v/${{version}}",
+        },
+      ],
+    },
+    {
+      schema: "/x/:module([a-z0-9_]*)/:path*",
+      variables: [
+        {
+          key: "module",
+          url: "https://api.deno.land/modules?simple=1",
+        },
+        {
+          key: "path",
+          url: "https://deno.land/_vsc1/modules/${module}/v_latest",
+        },
+      ],
+    },
+    {
+      schema: "/std@:version?/:path*",
+      variables: [
+        {
+          key: "version",
+          url: "https://deno.land/_vsc1/modules/std",
+        },
+        {
+          key: "path",
+          url: "https://deno.land/_vsc1/modules/std/v/${{version}}",
+        },
+      ],
+    },
+    {
+      schema: "/std/:path*",
+      variables: [
+        {
+          key: "path",
+          url: "https://deno.land/_vsc1/modules/std/v_latest",
+        },
+      ],
+    },
+  ],
+};
+
+/** This is the v2 registry configuration which provides documentation
+ * endpoints and allows incremental completion/search of variables. */
+const configV2: RegistryConfig = {
+  version: 2,
+  registries: [
+    {
+      schema: "/x/:module([a-z0-9_]+)@:version?/:path*",
+      variables: [
+        {
+          key: "module",
+          documentation: "/_api/details/x/${module}",
+          url: "/_api/x/${module}",
+        },
+        {
+          key: "version",
+          documentation: "/_api/details/x/${module}/${{version}}",
+          url: "/_api/x/${module}/${{version}}",
+        },
+        {
+          key: "path",
+          documentation: "/_api/details/x/${module}/${{version}}/${path}",
+          url: "/_api/x/${module}/${{version}}/${path}",
+        },
+      ],
+    },
+    {
+      schema: "/x/:module([a-z0-9_]*)/:path*",
+      variables: [
+        {
+          key: "module",
+          documentation: "/_api/details/x/${module}",
+          url: "/_api/x/${module}",
+        },
+        {
+          key: "path",
+          documentation: "/_api/details/x/${module}/_latest/${path}",
+          url: "/_api/x/${module}/_latest/${path}",
+        },
+      ],
+    },
+    {
+      schema: "/std@:version?/:path*",
+      variables: [
+        {
+          key: "version",
+          documentation: "/_api/details/std/${{version}}",
+          url: "/_api/x/std/${{version}}",
+        },
+        {
+          key: "path",
+          documentation: "/_api/details/std/${{version}}/${path}",
+          url: "/_api/x/std/${{version}}/${path}",
+        },
+      ],
+    },
+    {
+      schema: "/std/:path*",
+      variables: [
+        {
+          key: "path",
+          documentation: "/_api/details/std/_latest/${path}",
+          url: "/_api/x/std/_latest/${path}",
+        },
+      ],
+    },
+  ],
+};
+
+/** Provide the v1 or v2 registry configuration based on the accepts header
+ * provided by the client.  Deno 1.17.1 and later indicates it accepts a
+ * configuration of v2. */
+export function handleConfigRequest(request: Request): Promise<Response> {
+  let body: unknown;
+  let contentType = "application/json";
+  if (
+    request.headers.has("accept") &&
+    accepts(request, "application/vnd.deno.reg.v2+json")
+  ) {
+    contentType = "application/vnd.deno.reg.v2+json";
+    body = configV2;
+  } else {
+    body = configV1;
+  }
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      headers: {
+        "cache-control": MAX_AGE_1_DAY,
+        "content-type": contentType,
+      },
+    }),
+  );
+}

--- a/worker/registry_config_test.ts
+++ b/worker/registry_config_test.ts
@@ -1,0 +1,57 @@
+/* Copyright 2021-2022 the Deno authors. All rights reserved. MIT license. */
+
+import { assertEquals } from "https://deno.land/std@0.119.0/testing/asserts.ts";
+
+import { handleConfigRequest } from "./registry_config.ts";
+
+Deno.test({
+  name: "handleConfigRequest - v1 version of manifest",
+  async fn() {
+    const req = new Request(
+      "https://deno.land//.well-known/deno-import-intellisense.json",
+    );
+    const res = await handleConfigRequest(req);
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(json.version, 1);
+  },
+});
+
+Deno.test({
+  name: "handleConfigRequest - browser",
+  async fn() {
+    const req = new Request(
+      "https://deno.land//.well-known/deno-import-intellisense.json",
+      {
+        headers: {
+          "accept":
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+        },
+      },
+    );
+    const res = await handleConfigRequest(req);
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(json.version, 2);
+  },
+});
+
+Deno.test({
+  name: "handleConfigRequest - v2 version of manifest",
+  async fn() {
+    const req = new Request(
+      "https://deno.land//.well-known/deno-import-intellisense.json",
+      {
+        headers: {
+          // this is the accept header Deno v 1.17.1 and later sends in the request
+          accept:
+            "application/vnd.deno.reg.v2+json, application/vnd.deno.reg.v1+json;q=0.9, application/json;q=0.8",
+        },
+      },
+    );
+    const res = await handleConfigRequest(req);
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(json.version, 2);
+  },
+});

--- a/worker/suggestions.ts
+++ b/worker/suggestions.ts
@@ -1,0 +1,540 @@
+/* Copyright 2021 the Deno authors. All rights reserved. MIT license. */
+
+// @deno-types https://deno.land/x/fuse@v6.4.1/dist/fuse.d.ts
+import { default as Fuse } from "https://deno.land/x/fuse@v6.4.1/dist/fuse.esm.js";
+import { prettyBytes } from "https://deno.land/x/pretty_bytes@v1.0.5/mod.ts";
+import twas from "https://esm.sh/twas";
+
+import { S3_BUCKET } from "./registry.ts";
+
+interface ApiModuleData {
+  name: string;
+  description: string;
+  "star_count": number;
+}
+
+interface ApiModuleResponse {
+  data: ApiModuleData;
+}
+
+interface ApiModuleSearchResponse {
+  data: { results: ApiModuleData[] };
+}
+
+interface MetaVersionJson {
+  latest: string;
+  versions: string[];
+}
+
+interface MetaFileJson {
+  path: string;
+  size: number;
+  type: "dir" | "file";
+}
+
+interface MetaJson {
+  "uploaded_at": string;
+  "directory_listing": MetaFileJson[];
+  "upload_options": {
+    type: string;
+    repository: string;
+    ref: string;
+  };
+}
+
+interface PackageData {
+  name: string;
+  description: string;
+  stars: number;
+}
+
+const MODULE_LIST = "https://api.deno.land/modules?simple=1";
+const INITIAL_LIST = "https://api.deno.land/modules?limit=50&sort=stars";
+const MAX_AGE_1_HOUR = "max-age=3600";
+const MAX_AGE_1_DAY = "max-age=86400";
+const IMMUTABLE = "max-age=2628000, immutable";
+
+let fuse = new Fuse([], { includeScore: true, distance: 10 });
+let fuseUpdated = 0;
+
+/** A cache of all the package data retrieved from api.deno.land. */
+const packages = new Map<string, PackageData>();
+/** The initial list of packages displayed when there is no specific package
+ * being searched for.  Currently this will be the top 50 packages/modules in
+ * the registry order by star count. */
+let initialList: string[];
+/** A cache of all the package data retrieved from the S3 bucket. */
+const packageMeta = new Map<string, Map<string, MetaJson>>();
+/** A cache of a modules version data retrieved from the S3 bucket. */
+const versions = new Map<string, MetaVersionJson>();
+
+/** Descriptions of the packages/modules that are in `std`.
+ *
+ * TODO(@kitsonk): move to `std` as a JSON file which is retrieved. */
+const stdDescriptions: Record<string, string> = {
+  archive: "Utilities for handling archive formatted files",
+  async: "Utilities for helping with asynchronous tasks",
+  bytes: "Helper functions to manipulate byte slices",
+  collections:
+    "Pure functions for handling common tasks around collection types",
+  crypto: "Extensions to the web crypto APIs",
+  datetime:
+    "A hepler function to parse date strings into `Date` objects and additional functions",
+  encoding: "Helper modules for dealing with encoded data structures",
+  examples:
+    "Small scripts that demonstrate use of Deno and its standard modules",
+  flags: "Command line arguments parser for Deno based on minimist",
+  fmt: "Utilities for formatting strings for output",
+  fs: "Helpers associated with file system tasks",
+  hash: "**DEPRECATED** Use the Web Crypto APIs or `std/crypto` instead",
+  http: "Wrapper utilities for Deno's built-in HTTP server",
+  io: "Utility functions and classes to assist with IO tasks",
+  log: "A logging framework",
+  mime: "A utility for handling multi-part encoded bodies",
+  node: "Utilities and polyfills for Node.js built-in modules",
+  path: "Utility functions for manipulating file paths",
+  permissions: "A utility for granting sets of permissions in one API call",
+  signal: "A module used to capture and monitor OS signals",
+  streams:
+    "Utilities for working with Deno `Reader`/`Writer` interfaces and web streams",
+  testing: "Utilities for making testing easier and consistent in Deno",
+  textproto: "A port of Go's textproto",
+  uuid: "Utilities for generating v1, v4, and v5 UUIDs",
+  wasi: "Provides an implementation of the WebAssembly System Interface",
+};
+
+/** Cache the response from api.deno.land. */
+function cacheResponse({ data: { results } }: ApiModuleSearchResponse) {
+  for (const { name, description, star_count } of results) {
+    packages.set(name, { name, description, stars: star_count });
+  }
+}
+
+/** Fetch the meta data for a specific package/module and version from the S3
+ * bucket. */
+async function fetchMeta(pkg: string, ver: string): Promise<MetaJson> {
+  if (!packageMeta.has(pkg)) {
+    packageMeta.set(pkg, new Map());
+  }
+  const versionsMeta = packageMeta.get(pkg)!;
+  const res = await fetch(`${S3_BUCKET}${pkg}/versions/${ver}/meta/meta.json`);
+  if (res.status === 200) {
+    versionsMeta.set(ver, await res.json());
+  } else {
+    versionsMeta.set(ver, {
+      uploaded_at: "",
+      directory_listing: [],
+      upload_options: { type: "", repository: "", ref: "" },
+    });
+  }
+  return versionsMeta.get(ver)!;
+}
+
+/** Fetch the version data for a specific package/module from the S3 bucket. */
+async function fetchVersions(pkg: string): Promise<MetaVersionJson> {
+  const res = await fetch(`${S3_BUCKET}${pkg}/meta/versions.json`);
+  if (res.status === 200) {
+    versions.set(pkg, await res.json());
+  } else {
+    versions.set(pkg, { latest: "", versions: [] });
+  }
+  return versions.get(pkg)!;
+}
+
+/** Fetch package data from api.deno.land for a specific package/module. */
+async function fetchPackageData(pkg: string): Promise<PackageData> {
+  const res = await fetch(`https://api.deno.land/modules/${pkg}`);
+  if (res.status === 200) {
+    const { data: { name, description, star_count: stars } }:
+      ApiModuleResponse = await res.json();
+    packages.set(pkg, {
+      name,
+      description,
+      stars,
+    });
+  } else {
+    packages.set(pkg, {
+      name: pkg,
+      description: "",
+      stars: 0,
+    });
+  }
+  return packages.get(pkg)!;
+}
+
+/** Lazily update the module list for searching with fuse every 2 minutes and
+ * return a reference. */
+async function getFuse(): Promise<Fuse> {
+  const now = Date.now();
+  if (fuseUpdated + 120_000 < now) {
+    fuseUpdated = now;
+    const res = await fetch(MODULE_LIST);
+    if (res.status === 200) {
+      fuse = new Fuse(await res.json(), { includeScore: true, distance: 10 });
+    }
+  }
+  return fuse;
+}
+
+/** Git the initial package list to send to the client when no specific module
+ * is being searched for. */
+async function getInitialPackageList() {
+  if (!initialList) {
+    const res = await fetch(INITIAL_LIST);
+    if (res.status !== 200) {
+      throw new Error("bad api response");
+    }
+    const json: ApiModuleSearchResponse = await res.json();
+    cacheResponse(json);
+    initialList = toItems(json);
+  }
+  return initialList;
+}
+
+/** Given a package, return its latest version. */
+async function getLatestVersion(pkg: string): Promise<string> {
+  const data = versions.get(pkg) ?? await fetchVersions(pkg);
+  return data.latest;
+}
+
+function getMeta(pkg: string, ver: string): MetaJson | undefined {
+  return packageMeta.get(pkg)?.get(ver);
+}
+
+/** When dealing with a path, try to preselect the most logical module for the
+ * user. */
+function getPreselectPath(items: string[]): string | undefined {
+  // preselect anything that appears to be a root file in order
+  const preselect = [
+    "mod.ts",
+    "mod.js",
+    "lib.ts",
+    "lib.js",
+    "index.ts",
+    "index.mjs",
+    "index.js",
+  ]
+    .find((i) => items.includes(i));
+  if (preselect) {
+    return preselect;
+  }
+  // when navigating subdirs, then preselect the first thing we encounter that
+  // appears to be an root file in the subdir
+  return items.find((i) =>
+    [
+      "/mod.ts",
+      "/mod.js",
+      "/lib.ts",
+      "/lib.js",
+      "/index.ts",
+      "/index.mjs",
+      "/index.js",
+    ].find((s) => i.endsWith(s))
+  );
+}
+
+/** Given a package and optionally the current path, return a set of items
+ * that allows sub navigation of a directory structure. */
+function toFileItems(meta: MetaJson, currentPath = ""): string[] {
+  let dirs: string[] = [];
+  let items: string[] = [];
+  for (const { path, type } of meta.directory_listing) {
+    if (
+      type === "dir" && path.startsWith(`/${currentPath}`) &&
+      path !== (`/${currentPath}`) &&
+      !path.match(/\/[_.]/)
+    ) {
+      dirs.push(`${path.slice(1)}/`);
+    } else if (
+      path.startsWith(`/${currentPath}`) && path !== (`/${currentPath}`) &&
+      !path.match(/\/[_.]/) &&
+      path.match(/\.(jsx?|tsx?|mjs|cjs|mts|cts|json)$/i)
+    ) {
+      items.push(path.slice(1));
+    }
+  }
+  dirs = dirs.filter((dir) => items.some((item) => item.startsWith(dir)));
+  dirs = dirs.filter((dir) =>
+    !dir.replace(currentPath, "").slice(0, -1).includes("/")
+  );
+  items = items.filter((item) => !dirs.some((dir) => item.startsWith(dir)));
+  return [...dirs, ...items];
+}
+
+/** Convert an API search response into a list of module/package names. */
+function toItems({ data: { results } }: ApiModuleSearchResponse) {
+  return results.map(({ name }) => name);
+}
+
+function toPathDocs(
+  pkg: string,
+  ver: string,
+  path: string,
+  meta: MetaJson,
+): string {
+  const matchPath = `/${path}`;
+  const listing =
+    meta.directory_listing.find(({ path }) => path === matchPath) ??
+      { size: 0, type: "file", path: "" };
+  const { size, type } = listing;
+  return type === "file"
+    ? `[docs](https://doc.deno.land/https://deno.land/x/${pkg}@${ver}/${path}) | [code](https://deno.land/x/${pkg}@${ver}/${path}) | size: ${
+      prettyBytes(size)
+    }\n`
+    : `[code](https://deno.land/x/${pkg}@${ver}/${path}) | size: ${
+      prettyBytes(size)
+    }`;
+}
+
+function toStdVersionDocs(
+  ver: string,
+  meta: MetaJson,
+): string {
+  return `**Deno \`std\` library @ ${ver}**\n\nA collection of modules to assist with common tasks in Deno.\n\n[code](https://deno.land/std@${ver}) | published: _${
+    twas(new Date(meta.uploaded_at))
+  }_\n\n`;
+}
+
+function toStdPathDocs(ver: string, path: string, meta: MetaJson): string {
+  const matchPath = `/${path}`;
+  const listing =
+    meta.directory_listing.find(({ path }) => path === matchPath) ??
+      { size: 0, type: "file", path: "" };
+  const { size, type } = listing;
+  const [mod] = path && path.includes("/") ? path.split("/") : [path];
+  const leading = mod in stdDescriptions
+    ? `**${mod}**\n\n${stdDescriptions[mod] ?? ""}\n\n`
+    : "";
+  const body = type === "file"
+    ? `[docs](https://doc.deno.land/https://deno.land/std@${ver}/${path}) | [code](https://deno.land/std@${ver}/${path}) | size: ${
+      prettyBytes(size)
+    }\n`
+    : `[code](https://deno.land/std@${ver}/${path}) | size: ${
+      prettyBytes(size)
+    }`;
+  return `${leading}${body}`;
+}
+
+function toVersionDocs(
+  pkgData: PackageData,
+  ver: string,
+  meta: MetaJson,
+): string {
+  return `**${pkgData.name} @ ${ver}**\n\n${pkgData.description}\n\n[code](https://deno.land/x/${pkgData.name}@${ver}) | published: _${
+    twas(new Date(meta.uploaded_at))
+  }_${pkgData.stars ? ` | stars: _${pkgData.stars}_` : ""}\n\n`;
+}
+
+// /_api/details/x/:pkg
+async function handlePackageDetails(
+  match: URLPatternResult,
+): Promise<Response> {
+  const { pkg } = match.pathname.groups;
+  const pkgData = packages.get(pkg) ?? await fetchPackageData(pkg);
+  const body = {
+    kind: "markdown",
+    value:
+      `**${pkgData.name}**\n\n${pkgData.description}\n\n[code](https://deno.land/x/${pkg})${
+        pkgData.stars ? ` | stars: _${pkgData.stars}_` : ""
+      }\n\n`,
+  };
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      headers: {
+        "cache-control": MAX_AGE_1_DAY,
+        "content-type": "application/json",
+      },
+    }),
+  );
+}
+
+// /_api/x/:pkg
+async function handlePackages(match: URLPatternResult): Promise<Response> {
+  const { pkg } = match.pathname.groups;
+  if (!pkg) {
+    return new Response(
+      JSON.stringify({
+        items: await getInitialPackageList(),
+        isIncomplete: true,
+      }),
+      {
+        headers: {
+          "cache-control": MAX_AGE_1_HOUR,
+          "content-type": "application/json",
+        },
+      },
+    );
+  } else {
+    const fuse = await getFuse();
+    const foundItems = fuse.search(pkg);
+    const found: string[] = foundItems.map(({ item }: { item: string }) =>
+      item
+    );
+    const items = found.slice(0, 100);
+    const body = {
+      items,
+      isIncomplete: found.length > items.length,
+      preselect: (foundItems[0].score === 0) ? foundItems[0].item : undefined,
+    };
+    return new Response(JSON.stringify(body), {
+      headers: {
+        "cache-control": MAX_AGE_1_HOUR,
+        "content-type": "application/json",
+      },
+    });
+  }
+}
+
+// /_api/x/:pkg/:ver/:path
+async function handlePaths(match: URLPatternResult): Promise<Response> {
+  let { pkg, ver, path } = match.pathname.groups;
+  if (ver === "_latest") {
+    ver = await getLatestVersion(pkg);
+  }
+  const meta = getMeta(pkg, ver) ?? await fetchMeta(pkg, ver);
+  const items = toFileItems(meta, path);
+  const body = {
+    items,
+    isIncomplete: true,
+    preselect: getPreselectPath(items),
+  };
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "cache-control": IMMUTABLE,
+      "content-type": "application/json",
+    },
+  });
+}
+
+// /_api/x/:pkg/:ver
+async function handleVersions(match: URLPatternResult): Promise<Response> {
+  const { pkg, ver } = match.pathname.groups;
+  const versionInfo = versions.get(pkg) ?? await fetchVersions(pkg);
+  const items = ver
+    ? versionInfo.versions.filter((v) => v.startsWith(ver))
+    : versionInfo.versions;
+  const body = {
+    items,
+    isIncomplete: false,
+    preselect: items.find((v) => v === versionInfo.latest),
+  };
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "cache-control": MAX_AGE_1_HOUR,
+      "content-type": "application/json",
+    },
+  });
+}
+
+// /_api/details/x/:pkg/:ver/:path
+async function handlePathDetails(match: URLPatternResult): Promise<Response> {
+  let { pkg, ver, path } = match.pathname.groups;
+  if (ver === "_latest") {
+    ver = await getLatestVersion(pkg);
+  }
+  const meta = getMeta(pkg, ver) ?? await fetchMeta(pkg, ver);
+  const body = {
+    kind: "markdown",
+    value: toPathDocs(pkg, ver, path, meta),
+  };
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "cache-control": IMMUTABLE,
+      "content-type": "application/json",
+    },
+  });
+}
+
+// /_api/details/std/:ver
+async function handleStdVersionDetails(
+  match: URLPatternResult,
+): Promise<Response> {
+  const { ver } = match.pathname.groups;
+  const meta = getMeta("std", ver) ?? await fetchMeta("std", ver);
+  const body = {
+    kind: "markdown",
+    value: toStdVersionDocs(ver, meta),
+  };
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "cache-control": IMMUTABLE,
+      "content-type": "application/json",
+    },
+  });
+}
+
+// /_api/details/std/:ver/:path
+async function handleStdPathDetails(
+  match: URLPatternResult,
+): Promise<Response> {
+  let { ver, path } = match.pathname.groups;
+  if (ver === "_latest") {
+    ver = await getLatestVersion("std");
+  }
+  const meta = getMeta("std", ver) ?? await fetchMeta("std", ver);
+  const body = {
+    kind: "markdown",
+    value: toStdPathDocs(ver, path, meta),
+  };
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "cache-control": IMMUTABLE,
+      "content-type": "application/json",
+    },
+  });
+}
+
+// /_api/details/x/:pkg/:ver
+async function handleVersionDetails(
+  match: URLPatternResult,
+): Promise<Response> {
+  const { pkg, ver } = match.pathname.groups;
+  const pkgData = packages.get(pkg) ?? await fetchPackageData(pkg);
+  const meta = getMeta(pkg, ver) ?? await fetchMeta(pkg, ver);
+  const body = {
+    kind: "markdown",
+    value: toVersionDocs(pkgData, ver, meta),
+  };
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "cache-control": IMMUTABLE,
+      "content-type": "application/json",
+    },
+  });
+}
+
+/** Routes that get matched and delegated to sub handlers.*/
+const patterns: [string, (match: URLPatternResult) => Promise<Response>][] = [
+  ["/_api/x/{:pkg}?", handlePackages],
+  ["/_api/details/x/:pkg", handlePackageDetails],
+  ["/_api/x/:pkg/{:ver}?", handleVersions],
+  ["/_api/details/x/:pkg/:ver", handleVersionDetails],
+  ["/_api/x/:pkg/:ver/:path*{/}?", handlePaths],
+  ["/_api/details/x/:pkg/:ver/:path*{/}?", handlePathDetails],
+
+  ["/_api/details/std/:ver", handleStdVersionDetails],
+  ["/_api/details/std/:ver/:path*{/}?", handleStdPathDetails],
+];
+
+/** Handle registry v2 API requests. */
+export function handleApiRequest(url: URL): Promise<Response> {
+  for (const [pattern, handler] of patterns) {
+    const result = new URLPattern(pattern, url.toString()).exec(url);
+    if (result) {
+      try {
+        return handler(result);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "internal error";
+        return Promise.resolve(
+          new Response(msg, { status: 500, statusText: "InternalError" }),
+        );
+      }
+    }
+  }
+  return Promise.resolve(
+    new Response(null, {
+      status: 404,
+      statusText: "NotFound",
+    }),
+  );
+}

--- a/worker/suggestions_test.ts
+++ b/worker/suggestions_test.ts
@@ -1,4 +1,4 @@
-/* Copyright 2021 the Deno authors. All rights reserved. MIT license. */
+/* Copyright 2021-2022 the Deno authors. All rights reserved. MIT license. */
 
 import {
   assert,

--- a/worker/suggestions_test.ts
+++ b/worker/suggestions_test.ts
@@ -1,0 +1,160 @@
+/* Copyright 2021 the Deno authors. All rights reserved. MIT license. */
+
+import {
+  assert,
+  assertArrayIncludes,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.119.0/testing/asserts.ts";
+
+import { handleApiRequest } from "./suggestions.ts";
+
+Deno.test({
+  name: "/_api/x/ - get package list",
+  async fn() {
+    const res = await handleApiRequest(new URL("https://deno.land/_api/x/"));
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(json.items.length, 50);
+    assert(json.isIncomplete);
+  },
+});
+
+Deno.test({
+  name: "/_api/x/oak - package searching",
+  async fn() {
+    const res = await handleApiRequest(new URL("https://deno.land/_api/x/oak"));
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(json.items.length, 100);
+    assertEquals(json.items[0], "oak");
+    assert(json.isIncomplete);
+    assertEquals(json.preselect, "oak");
+  },
+});
+
+Deno.test({
+  name: "/_api/details/x/oak - package details",
+  async fn() {
+    const res = await handleApiRequest(
+      new URL("https://deno.land/_api/details/x/oak"),
+    );
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(json.kind, "markdown");
+    assert(json.value.startsWith("**oak**\n\n"));
+    assertStringIncludes(json.value, "[code](https://deno.land/x/oak)");
+  },
+});
+
+Deno.test({
+  name: "/_api/x/oak/ - versions, non-filtered",
+  async fn() {
+    const res = await handleApiRequest(
+      new URL("https://deno.land/_api/x/oak/"),
+    );
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(json.items[0], json.preselect);
+    assertArrayIncludes(json.items, ["v10.0.0", "v10.1.0"]);
+  },
+});
+
+Deno.test({
+  name: "/_api/x/oak/v9. - versions, filtered",
+  async fn() {
+    const res = await handleApiRequest(
+      new URL("https://deno.land/_api/x/oak/v9."),
+    );
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(json.preselect, undefined);
+    assertArrayIncludes(json.items, ["v9.0.1", "v9.0.0"]);
+  },
+});
+
+Deno.test({
+  name: "/_api/details/x/oak/v10.0.0 - version details",
+  async fn() {
+    const res = await handleApiRequest(
+      new URL("https://deno.land/_api/details/x/oak/v10.0.0"),
+    );
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(json.kind, "markdown");
+    assert(json.value.startsWith("**oak @ v10.0.0**\n\n"));
+    assertStringIncludes(json.value, "[code](https://deno.land/x/oak@v10.0.0)");
+  },
+});
+
+Deno.test({
+  name: "/_api/x/oak/_latest/ - latest paths",
+  async fn() {
+    const res = await handleApiRequest(
+      new URL("https://deno.land/_api/x/oak/_latest/"),
+    );
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(json.preselect, "mod.ts");
+    assertArrayIncludes(json.items, ["examples/", "mod.ts"]);
+    assert(json.isIncomplete);
+  },
+});
+
+Deno.test({
+  name: "/_api/x/oak/_latest/examples/ - latest paths filtered",
+  async fn() {
+    const res = await handleApiRequest(
+      new URL("https://deno.land/_api/x/oak/_latest/examples/"),
+    );
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    for (const item of json.items) {
+      assert(item.startsWith("examples/"));
+    }
+  },
+});
+
+Deno.test({
+  name: "/_api/details/x/oak/v10.0.0/mod.ts - details for path",
+  async fn() {
+    const res = await handleApiRequest(
+      new URL("https://deno.land/_api/details/x/oak/v10.0.0/mod.ts"),
+    );
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(
+      json.value,
+      "[docs](https://doc.deno.land/https://deno.land/x/oak@v10.0.0/mod.ts) | [code](https://deno.land/x/oak@v10.0.0/mod.ts) | size: 2.21 kB\n",
+    );
+  },
+});
+
+Deno.test({
+  name: "/_api/details/std/0.119.0 - std version details",
+  async fn() {
+    const res = await handleApiRequest(
+      new URL("https://deno.land/_api/details/std/0.119.0"),
+    );
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assert(json.value.startsWith(
+      "**Deno `std` library @ 0.119.0**\n\nA collection of modules to assist with common tasks in Deno.\n\n[code](https://deno.land/std@0.119.0) | published: ",
+    ));
+  },
+});
+
+Deno.test({
+  name: "/_api/details/std/0.119.0/testing/ - std path details",
+  async fn() {
+    const res = await handleApiRequest(
+      new URL("https://deno.land/_api/details/std/0.119.0/testing/"),
+    );
+    assertEquals(res.status, 200);
+    const json = await res.json();
+    assertEquals(
+      json.value,
+      "**testing**\n\nUtilities for making testing easier and consistent in Deno\n\n[code](https://deno.land/std@0.119.0/testing) | size: 110 kB",
+    );
+  },
+});


### PR DESCRIPTION
Closes: #1974

This PR:

- servers up the v1 or v2 configuration of the registry suggestions based on the client's support
- preserves the v1 suggestions (`/worker/vscode.ts`).
- adds several endpoints under (`/_api/`) which generates the responses for the v2 configuration
- proxies requests to `api.deno.land` pending full migration to deploy

The features it adds:

- Provides a fuzzy search for package/module names
- Provides documentation/details for packages, versions and paths as they are completed
- Provides completions for paths which reveal "folder by folder"
- Provides a summary of each sub-package/module in `std` to make it easier to explore `std`.
