### PR TITLE
feat: better content negotiation on code

### DIFF
--- a/worker/handler.ts
+++ b/worker/handler.ts
@@ -14,8 +14,7 @@ const REMOTE_URL = "https://deno-website2.now.sh";
 const ga = createReporter({
   filter(req, res) {
     const { pathname } = new URL(req.url);
-    const contentType = res.headers.get("content-type");
-    const isHtml = /html/i.test(contentType ?? "");
+    const isHtml = accepts(req, "application/*", "text/html") === "text/html";
     return pathname === "/" || pathname.startsWith("/std") ||
       pathname.startsWith("/x") || isHtml || res.status >= 400;
   },
@@ -25,10 +24,10 @@ const ga = createReporter({
     const userAgent = req.headers.get("user-agent");
 
     const { ok, statusText } = res;
-    const contentType = res.headers.get("content-type");
-    const isHtml = /html/i.test(contentType ?? "");
+    const isHtml = accepts(req, "application/*", "text/html") === "text/html";
 
     // Set the page title to "website" or "javascript" or "typescript" or "wasm"
+    const contentType = res.headers.get("content-type");
     let documentTitle;
     if (!ok) {
       documentTitle = statusText.toLowerCase();

--- a/worker/handler.ts
+++ b/worker/handler.ts
@@ -5,7 +5,7 @@ import { handleConfigRequest } from "./registry_config.ts";
 import { handleApiRequest } from "./suggestions.ts";
 import { handleVSCRequest } from "./vscode.ts";
 
-import type { ConnInfo } from "https://dotland-xkvnj8800ahg.deno.dev/std@0.112.0/http/server.ts";
+import type { ConnInfo } from "https://deno.land/std@0.112.0/http/server.ts";
 import { createReporter } from "https://deno.land/x/g_a@0.1.2/mod.ts";
 import { accepts } from "https://deno.land/x/oak_commons@0.1.1/negotiation.ts";
 

--- a/worker/handler.ts
+++ b/worker/handler.ts
@@ -7,6 +7,7 @@ import { handleVSCRequest } from "./vscode.ts";
 
 import type { ConnInfo } from "https://dotland-xkvnj8800ahg.deno.dev/std@0.112.0/http/server.ts";
 import { createReporter } from "https://deno.land/x/g_a@0.1.2/mod.ts";
+import { accepts } from "https://deno.land/x/oak_commons@0.1.1/negotiation.ts";
 
 const REMOTE_URL = "https://deno-website2.now.sh";
 
@@ -80,8 +81,10 @@ export function withLog(
 }
 
 export function handleRequest(request: Request): Promise<Response> {
-  const accept = request.headers.get("accept");
-  const isHtml = accept && accept.indexOf("html") >= 0;
+  // this checks to see if the requestor prefers "application" code over "html"
+  // which would be run-time clients who either omit an accept header (which
+  // implies any content type) or provides a `*/*` header
+  const isHtml = accepts(request, "application/*", "text/html") === "text/html";
 
   const url = new URL(request.url);
 

--- a/worker/handler_test.ts
+++ b/worker/handler_test.ts
@@ -3,6 +3,11 @@
 import { assert, assertEquals } from "./test_deps.ts";
 import { extractAltLineNumberReference, handleRequest } from "./handler.ts";
 
+/** This is taken directly from a recent version of Chromium */
+const BROWSER_ACCEPT =
+  "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9";
+const DENO_CLI_ACCEPT = "*/*";
+
 Deno.test({
   name: "/ responds with React html",
   async fn() {
@@ -20,7 +25,7 @@ Deno.test({
   async fn() {
     const result = await handleRequest(
       new Request("https://deno.land/std/version.ts", {
-        headers: { Accept: "text/html" },
+        headers: { Accept: BROWSER_ACCEPT },
       }),
     );
     assert(result.headers.get("Content-Type")?.includes("text/html"));
@@ -34,7 +39,7 @@ Deno.test({
   async fn() {
     const result = await handleRequest(
       new Request("https://deno.land/x/std/version.ts", {
-        headers: { Accept: "text/html" },
+        headers: { Accept: BROWSER_ACCEPT },
       }),
     );
     assert(result.headers.get("Content-Type")?.includes("text/html"));
@@ -44,10 +49,12 @@ Deno.test({
 });
 
 Deno.test({
-  name: "/x/std/version.ts with no Accept responds with redirect",
+  name: "/x/std/version.ts with Deno CLI Accept responds with redirect",
   async fn() {
     const result = await handleRequest(
-      new Request("https://deno.land/x/std/version.ts"),
+      new Request("https://deno.land/x/std/version.ts", {
+        headers: { Accept: DENO_CLI_ACCEPT },
+      }),
     );
     assertEquals(result.status, 302);
     assert(result.headers.get("Location")?.includes("@"));
@@ -62,7 +69,7 @@ Deno.test({
   async fn() {
     const result = await handleRequest(
       new Request("https://deno.land/std@0.50.0/version.ts", {
-        headers: { Accept: "text/html" },
+        headers: { Accept: BROWSER_ACCEPT },
       }),
     );
     assert(result.headers.get("Content-Type")?.includes("text/html"));
@@ -72,10 +79,13 @@ Deno.test({
 });
 
 Deno.test({
-  name: "/std@v0.50.0/version.ts with no Accept responds with raw typescript",
+  name:
+    "/std@v0.50.0/version.ts with Deno CLI Accept responds with raw typescript",
   async fn() {
     const result = await handleRequest(
-      new Request("https://deno.land/std@0.50.0/version.ts"),
+      new Request("https://deno.land/std@0.50.0/version.ts", {
+        headers: { Accept: DENO_CLI_ACCEPT },
+      }),
     );
     assert(result.headers.get("Content-Type")?.includes(
       "application/typescript",
@@ -91,7 +101,7 @@ Deno.test({
   async fn() {
     const result = await handleRequest(
       new Request("https://deno.land/x/std@0.50.0/version.ts", {
-        headers: { Accept: "text/html" },
+        headers: { Accept: BROWSER_ACCEPT },
       }),
     );
     assert(result.headers.get("Content-Type")?.includes("text/html"));
@@ -101,10 +111,13 @@ Deno.test({
 });
 
 Deno.test({
-  name: "/x/std@v0.50.0/version.ts with no Accept responds with raw typescript",
+  name:
+    "/x/std@v0.50.0/version.ts with Deno CLI Accept responds with raw typescript",
   async fn() {
     const result = await handleRequest(
-      new Request("https://deno.land/x/std@0.50.0/version.ts"),
+      new Request("https://deno.land/x/std@0.50.0/version.ts", {
+        headers: { Accept: DENO_CLI_ACCEPT },
+      }),
     );
     assert(result.headers.get("Content-Type")?.includes(
       "application/typescript",
@@ -120,7 +133,7 @@ Deno.test({
   async fn() {
     const result = await handleRequest(
       new Request("https://deno.land/std/fs/mod.ts:5:3", {
-        headers: { Accept: "text/html" },
+        headers: { Accept: BROWSER_ACCEPT },
       }),
     );
     assertEquals(result.status, 302);
@@ -134,7 +147,7 @@ Deno.test({
   async fn() {
     const result = await handleRequest(
       new Request("https://deno.land/std@0.50.0/fs/mod.ts:5:3", {
-        headers: { Accept: "text/html" },
+        headers: { Accept: BROWSER_ACCEPT },
       }),
     );
     assertEquals(result.status, 302);
@@ -150,7 +163,7 @@ Deno.test({
   async fn() {
     const result = await handleRequest(
       new Request("https://deno.land/x/std/fs/mod.ts:5:3", {
-        headers: { Accept: "text/html" },
+        headers: { Accept: BROWSER_ACCEPT },
       }),
     );
     assertEquals(result.status, 302);
@@ -164,7 +177,7 @@ Deno.test({
   async fn() {
     const result = await handleRequest(
       new Request("https://deno.land/x/std@0.50.0/fs/mod.ts:5:3", {
-        headers: { Accept: "text/html" },
+        headers: { Accept: BROWSER_ACCEPT },
       }),
     );
     assertEquals(result.status, 302);

--- a/worker/main.ts
+++ b/worker/main.ts
@@ -2,7 +2,7 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
 import { handleRequest, withLog } from "./handler.ts";
-import { listenAndServe } from "https://dotland-xkvnj8800ahg.deno.dev/std@0.108.0/http/server.ts";
+import { listenAndServe } from "https://deno.land/std@0.108.0/http/server.ts";
 
 const handler = withLog(handleRequest);
 

--- a/worker/registry_config.ts
+++ b/worker/registry_config.ts
@@ -1,6 +1,6 @@
 /* Copyright 2021 the Deno authors. All rights reserved. MIT license. */
 
-import { accepts } from "https://dotland-xkvnj8800ahg.deno.dev/x/oak_commons@0.1.1/negotiation.ts";
+import { accepts } from "https://deno.land/x/oak_commons@0.1.1/negotiation.ts";
 
 interface RegistryDefVariable {
   key: string;

--- a/worker/registry_config_test.ts
+++ b/worker/registry_config_test.ts
@@ -1,6 +1,6 @@
 /* Copyright 2021-2022 the Deno authors. All rights reserved. MIT license. */
 
-import { assertEquals } from "https://dotland-xkvnj8800ahg.deno.dev/std@0.119.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.119.0/testing/asserts.ts";
 
 import { handleConfigRequest } from "./registry_config.ts";
 

--- a/worker/suggestions.ts
+++ b/worker/suggestions.ts
@@ -1,8 +1,8 @@
 /* Copyright 2021-2022 the Deno authors. All rights reserved. MIT license. */
 
 // @deno-types https://deno.land/x/fuse@v6.4.1/dist/fuse.d.ts
-import { default as Fuse } from "https://dotland-xkvnj8800ahg.deno.dev/x/fuse@v6.4.1/dist/fuse.esm.js";
-import { prettyBytes } from "https://dotland-xkvnj8800ahg.deno.dev/x/pretty_bytes@v1.0.5/mod.ts";
+import { default as Fuse } from "https://deno.land/x/fuse@v6.4.1/dist/fuse.esm.js";
+import { prettyBytes } from "https://deno.land/x/pretty_bytes@v1.0.5/mod.ts";
 import twas from "https://esm.sh/twas@2.1.2";
 
 import { S3_BUCKET } from "./registry.ts";

--- a/worker/suggestions_test.ts
+++ b/worker/suggestions_test.ts
@@ -5,7 +5,7 @@ import {
   assertArrayIncludes,
   assertEquals,
   assertStringIncludes,
-} from "https://dotland-xkvnj8800ahg.deno.dev/std@0.119.0/testing/asserts.ts";
+} from "https://deno.land/std@0.119.0/testing/asserts.ts";
 
 import { handleApiRequest } from "./suggestions.ts";
 

--- a/worker/test_deps.ts
+++ b/worker/test_deps.ts
@@ -1,4 +1,4 @@
 export {
   assert,
   assertEquals,
-} from "https://dotland-xkvnj8800ahg.deno.dev/std@0.108.0/testing/asserts.ts";
+} from "https://deno.land/std@0.108.0/testing/asserts.ts";

--- a/worker/vscode.ts
+++ b/worker/vscode.ts
@@ -1,6 +1,6 @@
 /* Copyright 2020 the Deno authors. All rights reserved. MIT license. */
 
-import { match } from "https://dotland-xkvnj8800ahg.deno.dev/x/path_to_regexp@v6.2.0/index.ts";
+import { match } from "https://deno.land/x/path_to_regexp@v6.2.0/index.ts";
 import { S3_BUCKET } from "./registry.ts";
 
 const VERSIONS = match("/_vsc1/modules/:module([a-z0-9_]*)");


### PR DESCRIPTION
This properly fixes a minor improvement that was attempted in #1980 around determining if HTML should be served instead of code to a client.

It also aligns the tests for this to what is occurring in the real world, with an `Accept` header from a recent version of Chromium for browsers and `*/*` for those from the Deno CLI/Deploy which is what is passed from both of them currently.

It also reverts the dependencies served from a previous deployment of the worker.  We need to address how `deno.land` can depend on code itself hosts, but it feels unsafe to continue to leave the temporary URLs in the code base.