### PR TITLE
Use v1 registry config for old Deno versions

### DIFF
--- a/worker/registry_config.ts
+++ b/worker/registry_config.ts
@@ -155,8 +155,9 @@ const configV2: RegistryConfig = {
 export function handleConfigRequest(request: Request): Promise<Response> {
   let body: unknown;
   let contentType = "application/json";
+  const accept = request.headers.get("accept");
   if (
-    request.headers.has("accept") &&
+    accept !== null && accept !== "*/*" &&
     accepts(request, "application/vnd.deno.reg.v2+json")
   ) {
     contentType = "application/vnd.deno.reg.v2+json";

--- a/worker/registry_config_test.ts
+++ b/worker/registry_config_test.ts
@@ -8,7 +8,8 @@ Deno.test({
   name: "handleConfigRequest - v1 version of manifest",
   async fn() {
     const req = new Request(
-      "https://deno.land//.well-known/deno-import-intellisense.json",
+      "https://deno.land/.well-known/deno-import-intellisense.json",
+      { headers: { "accept": "*/*" } },
     );
     const res = await handleConfigRequest(req);
     assertEquals(res.status, 200);
@@ -21,7 +22,7 @@ Deno.test({
   name: "handleConfigRequest - browser",
   async fn() {
     const req = new Request(
-      "https://deno.land//.well-known/deno-import-intellisense.json",
+      "https://deno.land/.well-known/deno-import-intellisense.json",
       {
         headers: {
           "accept":
@@ -40,7 +41,7 @@ Deno.test({
   name: "handleConfigRequest - v2 version of manifest",
   async fn() {
     const req = new Request(
-      "https://deno.land//.well-known/deno-import-intellisense.json",
+      "https://deno.land/.well-known/deno-import-intellisense.json",
       {
         headers: {
           // this is the accept header Deno v 1.17.1 and later sends in the request


### PR DESCRIPTION
The v2 registry config was still sent to old Deno versions.
