### PR TITLE
Make the 'Go To Latest' button red

### DIFF
--- a/components/Registry.tsx
+++ b/components/Registry.tsx
@@ -781,7 +781,7 @@ function VersionSelector({
         ? (
           <button
             type="button"
-            className="mt-2 w-full inline-flex justify-center py-1 px-2 border border-gray-300 rounded-md bg-white text-sm leading-5 font-medium text-gray-500 hover:text-gray-400 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue transition duration-150 ease-in-out"
+            className="mt-2 w-full inline-flex justify-center py-1 px-2 border border-red-300 rounded-md bg-white text-sm leading-5 font-medium text-red-500 hover:text-gray-400 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue transition duration-150 ease-in-out"
             aria-label="Go to latest version"
             onClick={() => onChange(versions[0])}
           >


### PR DESCRIPTION
I feel like looking at an outdated version of a module should be brought to the attention of the developer. I have never noticed this button until @lucacasonato pointed it out to me :D

Before:
![Screenshot 2022-02-09 at 13 52 03](https://user-images.githubusercontent.com/234957/153215212-6a05abd2-c585-4eee-8c1a-0f6deeaae2b6.png)

After:
![Screenshot 2022-02-09 at 13 53 05](https://user-images.githubusercontent.com/234957/153215217-d16fb61b-02b5-4997-a67e-1b2376a1af95.png)

Closes #2006 