### PR TITLE
feat: add canonical url of manual pages

### DIFF
--- a/components/Manual.tsx
+++ b/components/Manual.tsx
@@ -236,6 +236,7 @@ function Manual(): React.ReactElement {
         <title>
           {pageTitle === "" ? "Manual | Deno" : `${pageTitle} | Manual | Deno`}
         </title>
+        <link rel="canonical" href={`https://deno.land/manual${path}`} />
         <link
           rel="preconnect"
           href="https://BH4D9OD16A-dsn.algolia.net"


### PR DESCRIPTION
This adds canonical url meta tags to the manual pages. ref. https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls

The effect of this change is that the search engines will always list the latest version of the same page in the search result instead of versioned pages.

For example, if I search for the query `deno config` in google now, the search result shows `https://deno.land/manual@v1.16.0/getting_started/configuration_file` (outdated version) for the first result. This will be changed to `https://deno.land/getting_started/configuration_file` (latest version) by this change.



closes #2010