### PR TITLE
feat: set canonical url to manual pages

### DIFF
--- a/pages/manual.tsx
+++ b/pages/manual.tsx
@@ -102,6 +102,7 @@ export default function Manual({ params, url }: PageProps) {
           rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/@docsearch/css@3"
         />
+	<link rel="canonical" href={`https://deno.land/manual${path}`} />
       </Head>
       <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3" />
       <div id="manualSearch" class="hidden" />


### PR DESCRIPTION
This PR sets the canonical url to manual pages. This should deduplicate the versions of the same page in google search result.

closes #2010 