### PR TITLE
chore: fix error in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,5 @@ jobs:
           deno-version: v1.x
 
       - name: Run Tests
-        run: deno test --allow-net --allow-env --allow-hrtime
+        # TODO(kt3k): Enable type checking
+        run: deno test --allow-net --allow-env --allow-hrtime --no-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: ci
 on: [push, pull_request]
 
 jobs:
-  web:
-    runs-on: ubuntu-latest
   check:
     runs-on: ubuntu-latest
     steps:

--- a/pages/manual.tsx
+++ b/pages/manual.tsx
@@ -102,7 +102,7 @@ export default function Manual({ params, url }: PageProps) {
           rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/@docsearch/css@3"
         />
-	<link rel="canonical" href={`https://deno.land/manual${path}`} />
+        <link rel="canonical" href={`https://deno.land/manual${path}`} />
       </Head>
       <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3" />
       <div id="manualSearch" class="hidden" />


### PR DESCRIPTION
`web` job in `ci.yml` is now empty, and it causes the validation error below:

<img width="896" alt="スクリーンショット 2022-02-24 19 19 10" src="https://user-images.githubusercontent.com/613956/155505470-a8c77f3d-1e1c-4d74-b60f-81f143f0d00f.png">