### PR TITLE
Fix typo in history section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ request to Vercel. (We use Vercel because of their nice GitHub integration.)
 
 ## History
 
-This is a rewrite of the Deno website it will combine the code in
+This is a rewrite of the Deno website. It will combine the code in
 https://github.com/denoland/deno/tree/f96aaa802b245c8b3aeb5d57b031f8a55bb07de2/website
 and https://github.com/denoland/registry and have faster deployment.
 


### PR DESCRIPTION
This fixes a small grammatical error in this page's README.md.