### PR TITLE
Restore inline display of Markdown images

### DIFF
--- a/static/app.css
+++ b/static/app.css
@@ -183,3 +183,7 @@ ul.tree li:before {
 ul.tree li:last-child:before {
 	border-left: 1px solid rgb(100, 100, 100);
 }
+
+.markdown-body img {
+    display: inline;
+}


### PR DESCRIPTION
Fix #2038
Test: https://dotland-fresh-ggcxpmcsd6tg.deno.dev/x/cronnor@v1.3.0/README.md

I'm not sure but probably there are more issues caused by CSS reset 🤷