### PR TITLE
Fix missing whitespace in benchmarks page

### DIFF
--- a/pages/benchmarks.tsx
+++ b/pages/benchmarks.tsx
@@ -168,7 +168,7 @@ export default function Benchmarks(props: PageProps<{ show: ShowData }>) {
             <p class="mt-4">
               You are currently viewing data for{" "}
               {showAll ? "all" : "the most recent"} commits to the{" "}
-              <a href="https://github.com/denoland/deno">main</a>
+              <a href="https://github.com/denoland/deno">main</a>{" "}
               branch. You can also view{" "}
               <a
                 class="link"


### PR DESCRIPTION
There's a missing whitespace as you can see in this screenshot

<img width="730" alt="image" src="https://user-images.githubusercontent.com/50486/157535236-b6570fa2-ae33-4831-934f-49b1a1fdaede.png">

I followed the same approach than in the line above to fix it.