### PR TITLE
add toolchain to home page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -239,10 +239,10 @@ Emit "colors.bundle.js" (9.83KB)`;
           </a>
           <p class="my-4 text-gray-700">
             Deno comes with a robust{" "}
-            <a class="link" href="/manual/tools">set of tools</a>, so
-            you can spend less time searching and evaluating third party
-            modules, and more time writing code and being productive. Here are a
-            few examples.
+            <a class="link" href="/manual/tools">set of tools</a>, so you can
+            spend less time searching and evaluating third party modules, and
+            more time writing code and being productive. Here are a few
+            examples.
           </p>
           <p class="my-4 text-gray-700">
             <a class="link" href="/manual/tools/linter">Lint</a>{" "}
@@ -255,8 +255,7 @@ Emit "colors.bundle.js" (9.83KB)`;
             />
           </p>
           <p class="my-4 text-gray-700">
-            <a class="link" href="/manual/tools/formatter">Format</a>
-            {" "}
+            <a class="link" href="/manual/tools/formatter">Format</a>{" "}
             all supported files in the current directory and subdirectories:
           </p>
           <p>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,6 +17,13 @@ export default function Home() {
 console.log("http://localhost:8000/");
 serve((req) => new Response("Hello World\\n"), { port: 8000 });`;
 
+  const denoBundleExample =
+    `deno bundle https://deno.land/std@0.132.0/examples/colors.ts colors.bundle.js
+Bundle https://deno.land/std@0.132.0/examples/colors.ts
+Download https://deno.land/std@0.132.0/examples/colors.ts
+Download https://deno.land/std@0.132.0/fmt/colors.ts
+Emit "colors.bundle.js" (9.83KB)`;
+
   return (
     <div>
       <Head>
@@ -205,6 +212,55 @@ serve((req) => new Response("Hello World\\n"), { port: 8000 });`;
             deno.land also provides a simple public hosting service for ES
             modules that work with Deno. It can be found at{" "}
             <a class="link" href="/x">deno.land/x</a>.
+          </p>
+        </div>
+        <div class="max-w-screen-sm mx-auto px-4 sm:px-6 md:px-8 mt-20">
+          <a class="hover:underline" href="#toolchain">
+            <h3 class="font-bold text-xl" id="toolchain">
+              Built-in Toolchain
+            </h3>
+          </a>
+          <p class="my-4 text-gray-700">
+            Deno comes with a robust{" "}
+            <a class="link" href="/manual@v1.20.3/tools">set of tools</a>, so
+            you can spend less time searching and evaluating third party
+            modules, and more time writing code and being productive. Here are a
+            few examples.
+          </p>
+          <p class="my-4 text-gray-700">
+            <a class="link" href="/manual@v1.20.3/tools/linter">Lint</a>{" "}
+            all JS/TS files in the current directory and subdirectories:
+          </p>
+          <p>
+            <CodeBlock
+              code={"deno lint\nChecked `n` files"}
+              language="bash"
+            />
+          </p>
+          <p class="my-4 text-gray-700">
+            <a class="link" href="/manual@1.20.3/tools/formatter">Format</a>
+            {" "}
+            all supported files in the current directory and subdirectories:
+          </p>
+          <p>
+            <CodeBlock
+              code={"deno fmt\nChecked `n` files"}
+              language="bash"
+            />
+          </p>
+          <p class="my-4 text-gray-700">
+            <a class="link" href="/manual@v1.20.3/tools/bundler">Bundle</a>{" "}
+            your project into a single JS file, including all dependencies:
+          </p>
+          <p>
+            <CodeBlock
+              code={denoBundleExample}
+              language="bash"
+            />
+          </p>
+          <p class="my-4 text-gray-700">
+            For the full list of tools and their options, see{" "}
+            <a href="/manual@v1.20.3/tools" class="link">here</a>.
           </p>
         </div>
         <div class="max-w-screen-sm mx-auto px-4 sm:px-6 md:px-8 mt-20">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -69,14 +69,14 @@ Emit "colors.bundle.js" (9.83KB)`;
             <li>Ships only a single executable file.</li>
             <li>
               Has{" "}
-              <a class="link" href="/manual@v1.20.3/tools">
+              <a class="link" href="/manual/tools">
                 built-in utilities
               </a>{" "}
               like a dependency inspector (
-              <a class="link" href="/manual@v1.20.3/tools/dependency_inspector">
+              <a class="link" href="/manual/tools/dependency_inspector">
                 <InlineCode>deno info</InlineCode>
               </a>) and a code formatter (
-              <a class="link" href="/manual@v1.20.3/tools/formatter">
+              <a class="link" href="/manual/tools/formatter">
                 <InlineCode>deno fmt</InlineCode>
               </a>).
             </li>
@@ -209,13 +209,13 @@ Emit "colors.bundle.js" (9.83KB)`;
           <p class="my-4 text-gray-700">
             To make it easier to consume third party modules Deno provides some
             built in tooling like{" "}
-            <a class="link" href="/manual@v1.20.3/tools/dependency_inspector">
+            <a class="link" href="/manual/tools/dependency_inspector">
               <InlineCode>deno info</InlineCode>
             </a>{" "}
             and{" "}
             <a
               class="link"
-              href="/manual@v1.20.3/tools/documentation_generator"
+              href="/manual/tools/documentation_generator"
             >
               <InlineCode>deno doc</InlineCode>
             </a>. deno.land also provides a web UI for viewing module
@@ -239,13 +239,13 @@ Emit "colors.bundle.js" (9.83KB)`;
           </a>
           <p class="my-4 text-gray-700">
             Deno comes with a robust{" "}
-            <a class="link" href="/manual@v1.20.3/tools">set of tools</a>, so
+            <a class="link" href="/manual/tools">set of tools</a>, so
             you can spend less time searching and evaluating third party
             modules, and more time writing code and being productive. Here are a
             few examples.
           </p>
           <p class="my-4 text-gray-700">
-            <a class="link" href="/manual@v1.20.3/tools/linter">Lint</a>{" "}
+            <a class="link" href="/manual/tools/linter">Lint</a>{" "}
             all JS/TS files in the current directory and subdirectories:
           </p>
           <p>
@@ -255,7 +255,7 @@ Emit "colors.bundle.js" (9.83KB)`;
             />
           </p>
           <p class="my-4 text-gray-700">
-            <a class="link" href="/manual@1.20.3/tools/formatter">Format</a>
+            <a class="link" href="/manual/tools/formatter">Format</a>
             {" "}
             all supported files in the current directory and subdirectories:
           </p>
@@ -266,7 +266,7 @@ Emit "colors.bundle.js" (9.83KB)`;
             />
           </p>
           <p class="my-4 text-gray-700">
-            <a class="link" href="/manual@v1.20.3/tools/bundler">Bundle</a>{" "}
+            <a class="link" href="/manual/tools/bundler">Bundle</a>{" "}
             your project into a single JS file, including all dependencies:
           </p>
           <p>
@@ -277,7 +277,7 @@ Emit "colors.bundle.js" (9.83KB)`;
           </p>
           <p class="my-4 text-gray-700">
             For the full list of tools and their options, see{" "}
-            <a href="/manual@v1.20.3/tools" class="link">here</a>.
+            <a href="/manual/tools" class="link">here</a>.
           </p>
         </div>
         <div class="max-w-screen-sm mx-auto px-4 sm:px-6 md:px-8 mt-20">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -68,9 +68,17 @@ Emit "colors.bundle.js" (9.83KB)`;
             <li>Supports TypeScript out of the box.</li>
             <li>Ships only a single executable file.</li>
             <li>
-              Has built-in utilities like a dependency inspector (
-              <InlineCode>deno info</InlineCode>) and a code formatter (
-              <InlineCode>deno fmt</InlineCode>).
+              Has{" "}
+              <a class="link" href="/manual@v1.20.3/tools">
+                built-in utilities
+              </a>{" "}
+              like a dependency inspector (
+              <a class="link" href="/manual@v1.20.3/tools/dependency_inspector">
+                <InlineCode>deno info</InlineCode>
+              </a>) and a code formatter (
+              <a class="link" href="/manual@v1.20.3/tools/formatter">
+                <InlineCode>deno fmt</InlineCode>
+              </a>).
             </li>
             <li>
               Has a set of reviewed (audited) standard modules that are
@@ -200,9 +208,18 @@ Emit "colors.bundle.js" (9.83KB)`;
           </p>
           <p class="my-4 text-gray-700">
             To make it easier to consume third party modules Deno provides some
-            built in tooling like <InlineCode>deno info</InlineCode> and{" "}
-            <InlineCode>deno doc</InlineCode>. deno.land also provides a web UI
-            for viewing module documentation. It is available at{" "}
+            built in tooling like{" "}
+            <a class="link" href="/manual@v1.20.3/tools/dependency_inspector">
+              <InlineCode>deno info</InlineCode>
+            </a>{" "}
+            and{" "}
+            <a
+              class="link"
+              href="/manual@v1.20.3/tools/documentation_generator"
+            >
+              <InlineCode>deno doc</InlineCode>
+            </a>. deno.land also provides a web UI for viewing module
+            documentation. It is available at{" "}
             <a href="https://doc.deno.land" class="link">
               doc.deno.land
             </a>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,12 +17,14 @@ export default function Home() {
 console.log("http://localhost:8000/");
 serve((req) => new Response("Hello World\\n"), { port: 8000 });`;
 
-  const denoBundleExample =
-    `deno bundle https://deno.land/std@0.132.0/examples/colors.ts colors.bundle.js
-Bundle https://deno.land/std@0.132.0/examples/colors.ts
-Download https://deno.land/std@0.132.0/examples/colors.ts
-Download https://deno.land/std@0.132.0/fmt/colors.ts
-Emit "colors.bundle.js" (9.83KB)`;
+  const denoTestExample =
+    `deno test https://deno.land/std@0.132.0/testing/chai_example.ts
+running 3 tests from https://deno.land/std@0.132.0/testing/chai_example.ts
+test we can make chai assertions ... ok (8ms)
+test we can make chai expectations ... ok (2ms)
+test we can use chai should style ... ok (4ms)
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (27ms)`;
 
   return (
     <div>
@@ -250,7 +252,7 @@ Emit "colors.bundle.js" (9.83KB)`;
           </p>
           <p>
             <CodeBlock
-              code={"deno lint\nChecked `n` files"}
+              code={"deno lint\nChecked 54 files"}
               language="bash"
             />
           </p>
@@ -260,17 +262,16 @@ Emit "colors.bundle.js" (9.83KB)`;
           </p>
           <p>
             <CodeBlock
-              code={"deno fmt\nChecked `n` files"}
+              code={"deno fmt\nChecked 46 files"}
               language="bash"
             />
           </p>
           <p class="my-4 text-gray-700">
-            <a class="link" href="/manual/tools/bundler">Bundle</a>{" "}
-            your project into a single JS file, including all dependencies:
+            Run a <a class="link" href="/manual/tools/testing">test</a>:
           </p>
           <p>
             <CodeBlock
-              code={denoBundleExample}
+              code={denoTestExample}
               language="bash"
             />
           </p>


### PR DESCRIPTION
after talking to some deno users, some of them are surprised to learn about how robust and useful the built-in toolchain is. 

this is just a quick pass at featuring the toolchain in a more prominent way.

also, right now some links point to version 1.20.3 of the manual. is there a way to future proof linking to that particular version (e.g. is there a `version` variable that i can put into the anchor tag)?