### PR TITLE
fix: use root readme if present

### DIFF
--- a/util/registry_utils.test.ts
+++ b/util/registry_utils.test.ts
@@ -198,6 +198,26 @@ Deno.test("findRootReadme", () => {
   }
 });
 
+Deno.test("findRootReadme selection", () => {
+  {
+    const rootReadme = findRootReadme([
+      { path: "/.github/README.md", type: "file", size: 100 },
+      { path: "/docs/README.md", type: "file", size: 100 },
+      { path: "/README.md", type: "file", size: 100 },
+    ]);
+
+    assertEquals(rootReadme?.name, "README.md");
+  }
+  {
+    const rootReadme = findRootReadme([
+      { path: "/.github/README.md", type: "file", size: 100 },
+      { path: "/docs/README.md", type: "file", size: 100 },
+    ]);
+
+    assertEquals(rootReadme?.name, "docs/README.md");
+  }
+});
+
 Deno.test("isReadme", () => {
   const tests: Array<[string, boolean]> = [
     ["README", true],

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -336,11 +336,15 @@ export function denoDocAvailableForURL(filename: string): boolean {
 export function findRootReadme(
   directoryListing: DirListing[] | undefined,
 ): DirEntry | undefined {
-  const listing = directoryListing?.find((d) =>
-    new RegExp(`^\\/(docs\\/|\\.github\\/)?${readmeBaseRegex}$`, "i").test(
-      d.path,
-    )
-  );
+  const listing =
+    directoryListing?.filter((d) =>
+      new RegExp(`^\\/(docs\\/|\\.github\\/)?${readmeBaseRegex}$`, "i").test(
+        d.path,
+      )
+    ).sort((a, b) => {
+      return a.path.length - b.path.length;
+    })[0];
+
   return listing
     ? {
       name: listing.path.substring(1),


### PR DESCRIPTION
This PR uses the relative project path length to sort the possible root readme candidates so that if present, the root one is used in favour of others.

resolves #2069