### PR TITLE
fix: manual redirect handling in proxy

### DIFF
--- a/worker/handler.ts
+++ b/worker/handler.ts
@@ -192,7 +192,7 @@ export function extractAltLineNumberReference(
 async function proxyFile(url: URL, remoteUrl: string): Promise<Response> {
   const proxyUrl = new URL(remoteUrl + url.pathname + url.search).href;
 
-  const proxyRequest = new Request(proxyUrl);
+  const proxyRequest = new Request(proxyUrl, { redirect: "manual" });
   const proxyResponse = await fetchWithRetry(proxyRequest);
 
   return proxyResponse;


### PR DESCRIPTION
Fixes the website not redirecting deno.land/std to deno.land/std@0.134.0