### PR TITLE
feat(registry): add next page button for module search

### DIFF
--- a/components/Pagination.tsx
+++ b/components/Pagination.tsx
@@ -15,6 +15,14 @@ interface Props extends PaginationProps {
   };
 }
 
+function getNavButtonStyles(disabled: boolean) {
+  return `relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm leading-5 font-medium rounded-md bg-white ${
+    !disabled
+      ? "text-gray-700 hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700"
+      : "text-gray-500 cursor-default"
+  } transition ease-in-out duration-150`;
+}
+
 export function Pagination(
   { query, hasNext, hasPrevious, currentPage, pageCount, perPage, response }:
     Props,
@@ -35,196 +43,204 @@ export function Pagination(
 
   return (
     <div class="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6">
-      <div class="flex-1 flex justify-between items-center sm:hidden">
-        <MaybeA
-          disabled={!hasPrevious}
-          href={toPage(currentPage - 1)}
-          class={`relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm leading-5 font-medium rounded-md bg-white ${
-            hasPrevious
-              ? "text-gray-700 hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700"
-              : "text-gray-500 cursor-default"
-          } transition ease-in-out duration-150`}
-        >
-          Previous
-        </MaybeA>
-        <div class="text-base leading-6 text-gray-500">
-          {currentPage}/{pageCount}
-        </div>
-        <MaybeA
-          disabled={!hasNext}
-          href={toPage(currentPage + 1)}
-          class={`relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm leading-5 font-medium rounded-md bg-white ml-4 ${
-            hasNext
-              ? "text-gray-700 hover:text-gray-500 focus:outline-none focus:shadow-outline-blue focus:border-blue-300 active:bg-gray-100 active:text-gray-700"
-              : "text-gray-500 cursor-default"
-          } transition ease-in-out duration-150`}
-        >
-          Next
-        </MaybeA>
-      </div>
-      <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
-        <div>
-          <p class="text-sm leading-5 text-gray-700">
-            Showing{" "}
-            <span class="font-medium">
-              {(currentPage - 1) * perPage + 1}
-            </span>{" "}
-            to{" "}
-            <span class="font-medium">
-              {(currentPage - 1) * perPage + response.results.length}
-            </span>{" "}
-            of{" "}
-            <span class="font-medium">
-              {response.totalCount}
-            </span>{" "}
-            results
-          </p>
-        </div>
-        <div>
-          <nav class="relative z-0 inline-flex shadow-sm">
-            <MaybeA
-              disabled={!hasPrevious}
-              href={toPage(currentPage - 1)}
-              class={`relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm leading-5 font-medium ${
-                hasPrevious
-                  ? "text-gray-500 hover:text-gray-400 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500"
-                  : "text-gray-300 cursor-default"
-              } transition ease-in-out duration-150`}
-              aria-label="Previous"
-            >
-              <svg
-                class="h-5 w-5"
-                viewBox="0 0 20 20"
-                fill="currentColor"
+      {!query
+        ? (
+          <>
+            <div class="flex-1 flex justify-between items-center sm:hidden">
+              <MaybeA
+                disabled={!hasPrevious}
+                href={toPage(currentPage - 1)}
+                class={getNavButtonStyles(!hasPrevious)}
               >
-                <path
-                  fillRule="evenodd"
-                  d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
-                  clipRule="evenodd"
-                />
-              </svg>
-            </MaybeA>
-            <a
-              href={toPage(1)}
-              class={`inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
-                currentPage === 1
-                  ? "bg-gray-100 font-semibold text-gray-800"
-                  : "bg-white font-medium text-gray-700"
-              } hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
-            >
-              1
-            </a>
-            {centerPage === 4
-              ? (
-                <>
+                Previous
+              </MaybeA>
+              <div class="text-base leading-6 text-gray-500">
+                {currentPage}/{pageCount}
+              </div>
+              <MaybeA
+                disabled={!hasNext}
+                href={toPage(currentPage + 1)}
+                class={`${getNavButtonStyles(!hasNext)} ml-4`}
+              >
+                Next
+              </MaybeA>
+            </div>
+            <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+              <div>
+                <p class="text-sm leading-5 text-gray-700">
+                  Showing{" "}
+                  <span class="font-medium">
+                    {(currentPage - 1) * perPage + 1}
+                  </span>{" "}
+                  to{" "}
+                  <span class="font-medium">
+                    {(currentPage - 1) * perPage + response.results.length}
+                  </span>{" "}
+                  of{" "}
+                  <span class="font-medium">
+                    {response.totalCount}
+                  </span>{" "}
+                  results
+                </p>
+              </div>
+              <div>
+                <nav class="relative z-0 inline-flex shadow-sm">
+                  <MaybeA
+                    disabled={!hasPrevious}
+                    href={toPage(currentPage - 1)}
+                    class={`relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm leading-5 font-medium ${
+                      hasPrevious
+                        ? "text-gray-500 hover:text-gray-400 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500"
+                        : "text-gray-300 cursor-default"
+                    } transition ease-in-out duration-150`}
+                    aria-label="Previous"
+                  >
+                    <svg
+                      class="h-5 w-5"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </MaybeA>
                   <a
-                    href={toPage(2)}
-                    class={`hidden md:inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
-                      currentPage === 2
+                    href={toPage(1)}
+                    class={`inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
+                      currentPage === 1
                         ? "bg-gray-100 font-semibold text-gray-800"
                         : "bg-white font-medium text-gray-700"
                     } hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
                   >
-                    2
+                    1
                   </a>
-                  <span class="inline-flex md:hidden -ml-px relative items-center px-4 py-2 border border-gray-300 bg-white text-sm leading-5 font-medium text-gray-700">
-                    ...
-                  </span>
-                </>
-              )
-              : (
-                <span class="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white text-sm leading-5 font-medium text-gray-700">
-                  ...
-                </span>
-              )}
-            <a
-              href={toPage(centerPage - 1)}
-              class={`hidden md:inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
-                currentPage === centerPage - 1
-                  ? "bg-gray-100 font-semibold text-gray-800"
-                  : "bg-white font-medium text-gray-700"
-              } hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
-            >
-              {centerPage - 1}
-            </a>
-            <a
-              href={toPage(centerPage)}
-              class={`inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
-                currentPage === centerPage
-                  ? "bg-gray-100 font-semibold text-gray-800"
-                  : "bg-white font-medium text-gray-700"
-              } hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
-            >
-              {centerPage}
-            </a>
-            <a
-              href={toPage(centerPage + 1)}
-              class={`hidden md:inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
-                currentPage === centerPage + 1
-                  ? "bg-gray-100 font-semibold text-gray-800"
-                  : "bg-white font-medium text-gray-700"
-              } hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
-            >
-              {centerPage + 1}
-            </a>
-            {centerPage === pageCount - 3
-              ? (
-                <>
+                  {centerPage === 4
+                    ? (
+                      <>
+                        <a
+                          href={toPage(2)}
+                          class={`hidden md:inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
+                            currentPage === 2
+                              ? "bg-gray-100 font-semibold text-gray-800"
+                              : "bg-white font-medium text-gray-700"
+                          } hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
+                        >
+                          2
+                        </a>
+                        <span class="inline-flex md:hidden -ml-px relative items-center px-4 py-2 border border-gray-300 bg-white text-sm leading-5 font-medium text-gray-700">
+                          ...
+                        </span>
+                      </>
+                    )
+                    : (
+                      <span class="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white text-sm leading-5 font-medium text-gray-700">
+                        ...
+                      </span>
+                    )}
                   <a
-                    href={toPage(pageCount - 1)}
+                    href={toPage(centerPage - 1)}
                     class={`hidden md:inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
-                      currentPage === pageCount - 1
+                      currentPage === centerPage - 1
                         ? "bg-gray-100 font-semibold text-gray-800"
                         : "bg-white font-medium text-gray-700"
                     } hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
                   >
-                    {pageCount - 1}
+                    {centerPage - 1}
                   </a>
-                  <span class="inline-flex md:hidden -ml-px relative items-center px-4 py-2 border border-gray-300 bg-white text-sm leading-5 font-medium text-gray-700">
-                    ...
-                  </span>
-                </>
-              )
-              : (
-                <span class="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white text-sm leading-5 font-medium text-gray-700">
-                  ...
-                </span>
-              )}
-            <a
-              href={toPage(pageCount)}
-              class={`inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
-                currentPage === pageCount
-                  ? "bg-gray-100 font-semibold text-gray-800"
-                  : "bg-white font-medium text-gray-700"
-              } hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
-            >
-              {pageCount}
-            </a>
+                  <a
+                    href={toPage(centerPage)}
+                    class={`inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
+                      currentPage === centerPage
+                        ? "bg-gray-100 font-semibold text-gray-800"
+                        : "bg-white font-medium text-gray-700"
+                    } hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
+                  >
+                    {centerPage}
+                  </a>
+                  <a
+                    href={toPage(centerPage + 1)}
+                    class={`hidden md:inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
+                      currentPage === centerPage + 1
+                        ? "bg-gray-100 font-semibold text-gray-800"
+                        : "bg-white font-medium text-gray-700"
+                    } hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
+                  >
+                    {centerPage + 1}
+                  </a>
+                  {centerPage === pageCount - 3
+                    ? (
+                      <>
+                        <a
+                          href={toPage(pageCount - 1)}
+                          class={`hidden md:inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
+                            currentPage === pageCount - 1
+                              ? "bg-gray-100 font-semibold text-gray-800"
+                              : "bg-white font-medium text-gray-700"
+                          } hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
+                        >
+                          {pageCount - 1}
+                        </a>
+                        <span class="inline-flex md:hidden -ml-px relative items-center px-4 py-2 border border-gray-300 bg-white text-sm leading-5 font-medium text-gray-700">
+                          ...
+                        </span>
+                      </>
+                    )
+                    : (
+                      <span class="-ml-px relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white text-sm leading-5 font-medium text-gray-700">
+                        ...
+                      </span>
+                    )}
+                  <a
+                    href={toPage(pageCount)}
+                    class={`inline-flex -ml-px relative items-center px-4 py-2 border border-gray-300 text-sm leading-5 ${
+                      currentPage === pageCount
+                        ? "bg-gray-100 font-semibold text-gray-800"
+                        : "bg-white font-medium text-gray-700"
+                    } hover:text-gray-500 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-700 transition ease-in-out duration-150`}
+                  >
+                    {pageCount}
+                  </a>
+                  <MaybeA
+                    href={toPage(currentPage + 1)}
+                    disabled={!hasNext}
+                    class={`-ml-px relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm leading-5 font-medium ${
+                      hasNext
+                        ? "text-gray-500 hover:text-gray-400 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500"
+                        : "text-gray-300 cursor-default"
+                    } transition ease-in-out duration-150`}
+                    aria-label="Previous"
+                  >
+                    <svg
+                      class="h-5 w-5"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </MaybeA>
+                </nav>
+              </div>
+            </div>
+          </>
+        )
+        : (
+          <div className="flex flex-1 justify-center">
             <MaybeA
+              disabled={false}
               href={toPage(currentPage + 1)}
-              disabled={!hasNext}
-              class={`-ml-px relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm leading-5 font-medium ${
-                hasNext
-                  ? "text-gray-500 hover:text-gray-400 focus:z-10 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-100 active:text-gray-500"
-                  : "text-gray-300 cursor-default"
-              } transition ease-in-out duration-150`}
-              aria-label="Previous"
+              class={getNavButtonStyles(false)}
             >
-              <svg
-                class="h-5 w-5"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
-                  clipRule="evenodd"
-                />
-              </svg>
+              Next
             </MaybeA>
-          </nav>
-        </div>
-      </div>
+          </div>
+        )}
     </div>
   );
 }

--- a/pages/x/index.tsx
+++ b/pages/x/index.tsx
@@ -128,7 +128,7 @@ export default function ThirdPartyRegistryList({ url }: PageProps) {
                         }))}
                       />
                     )}
-                  {!query && resp.results.length
+                  {resp.results.length
                     ? (() => {
                       const pageCount = pageutils.pageCount({
                         totalCount: resp.totalCount,
@@ -150,6 +150,7 @@ export default function ThirdPartyRegistryList({ url }: PageProps) {
                             pageCount,
                             perPage: PER_PAGE,
                             response: resp,
+                            query,
                           }}
                         />
                       );


### PR DESCRIPTION
This adds a **"Next"** button to the bottom of the search results in the registry, so users can navigate to the next page of results without updating the url manually.

<img width="669" alt="Screenshot 2022-04-14 at 14 22 30" src="https://user-images.githubusercontent.com/45368713/163389605-bbe66f57-4470-4f19-ae28-90ee1d6675d0.png">

As far as I could figure it out from the registry's source code, searching is sorting all the modules based on a scoring function, and returns the first 20, meaning we don't have a "number of results"  here and users can eventually get to a page with no related results.

Also, I've seen the api handler checks sorting by _newest_ / _oldest_ / _stars_ by url parameter, but that doesn't seem like working currently (https://deno.land/x?sort=newest).

towards #2104 