### PR TITLE
don't hide the gradient on smaller screens

### DIFF
--- a/components/HeroBackground.tsx
+++ b/components/HeroBackground.tsx
@@ -7,8 +7,8 @@ import { h } from "../deps.ts";
 export function Background() {
   return (
     <div class="pointer-events-none">
-      <BlueGradient class="absolute inset-0 hidden lg:block" />
-      <RedGradient class="absolute inset-0 left-10 hidden lg:block" />
+      <BlueGradient class="absolute inset-0" />
+      <RedGradient class="absolute inset-0 left-10" />
     </div>
   );
 }


### PR DESCRIPTION
This makes the hero gradient visible on smaller screens too. (I thought it was intentionally hidden based on the [original gist](https://gist.github.com/ry/a0532ce538e6331947e6755e8f512b43#file-background-tsx-L8).)

closes #2118 