### PR TITLE
nicer layout for Deno in Production section

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -345,63 +345,60 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (27ms
             .
           </p>
         </div>
-        <div class="max-w-screen-sm mx-auto px-4 sm:px-6 md:px-8 mt-20">
-          <a class="hover:underline" href="#examples">
-            <h3 class="font-bold text-xl" id="examples">
-              Deno in Production
-            </h3>
-          </a>
-          <ol class="mt-5 ml-8 list-disc text-gray-700">
-            <li>
-              <a href="https://slack.com/" target="_blank">
-                <img
-                  class="h-4 inline-block"
-                  src="https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/slack.svg"
-                  alt="Slack"
-                  title="Slack"
-                />{" "}
-                <span class="link">Slack</span>
-              </a>
-            </li>
-            <li>
-              <a href="https://github.com/" target="_blank">
-                <img
-                  class="h-4 inline-block"
-                  src="https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/github.svg"
-                  alt="GitHub"
-                  title="GitHub"
-                />{" "}
-                <span class="link">GitHub</span>
-              </a>
-            </li>
-            <li>
-              <a href="https://netlify.com" target="_blank">
-                <img
-                  class="h-4 inline-block"
-                  src="https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/netlify.svg"
-                  alt="Netlify"
-                  title="Netlify"
-                />{" "}
-                <span class="link">Netlify</span>
-              </a>
-            </li>
-            <li>
-              <a href="https://supabase.com" target="_blank">
-                <img
-                  class="h-4 inline-block"
-                  src="https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/supabase.svg"
-                  alt="Supabase"
-                  title="Supabase"
-                />{" "}
-                <span class="link">Supabase</span>
-              </a>
-            </li>
-          </ol>
-        </div>
+        <DenoInProductionSection />
         <div class="mt-20">
           <Footer simple />
         </div>
       </div>
+    </div>
+  );
+}
+
+function DenoInProductionSection() {
+  const companies = [{
+    name: "Slack",
+    logo: "slack.svg",
+    url: "https://slack.com",
+  }, {
+    name: "Netlify",
+    logo: "netlify.svg",
+    url: "https://netlify.com",
+  }, {
+    name: "GitHub",
+    logo: "github.svg",
+    url: "https://github.com",
+  }, {
+    name: "Supabase",
+    logo: "supabase.svg",
+    url: "https://supabase.com",
+  }];
+
+  return (
+    <div class="max-w-screen-sm mx-auto px-4 sm:px-6 md:px-8 mt-20">
+      <a class="hover:underline" href="#deno-in-production">
+        <h3 class="font-bold text-xl" id="deno-in-production">
+          Deno in Production
+        </h3>
+      </a>
+      <ol class="pl-1 md:pl-0 md:flex flex-wrap gap-8 mt-5 list-none">
+        {companies.map(({ name, logo, url }) => (
+          <li class="mb-2 md:mb-0" key={url}>
+            <a
+              class="flex items-center gap-2 flex-nowrap opacity-70 hover:opacity-100"
+              href={url}
+              target="_blank"
+            >
+              <img
+                class="w-5"
+                src={`https://cdn.jsdelivr.net/npm/simple-icons@v6/icons/${logo}`}
+                alt={name}
+                title={name}
+              />{" "}
+              <span class="font-medium text-lg">{name}</span>
+            </a>
+          </li>
+        ))}
+      </ol>
     </div>
   );
 }


### PR DESCRIPTION
followup to #2116 

This adds a(n arguably) nicer design for the Deno in Production section on the homepage. 

 - aligns the companies in a row on desktop (on mobile they remain vertical)
 - centers the logo and the name vertically
 - makes the items 70% opaque, 100% on hover
 - makes them slightly bigger

I'm open to feedback and suggestions! Some more ideas here: https://github.com/denoland/dotland/pull/2116#issuecomment-1107449899

Also fixes the `id` and `href` of the section, and extracts it to a component with a loop to make it easier to add more companies later.

Desktop: 

![image](https://user-images.githubusercontent.com/45368713/164986008-2f084fc5-acea-4bfb-9e28-15e9e9bcc695.png)

Mobile:

![image](https://user-images.githubusercontent.com/45368713/164986095-393c06e8-2e2f-4ad8-8153-fd7f711a075c.png)



