### PR TITLE
Show full showcase images

### DIFF
--- a/pages/showcase.tsx
+++ b/pages/showcase.tsx
@@ -56,7 +56,7 @@ function Item({ project }: { project: Project }) {
         <img
           src={project.image}
           alt={project.title}
-          class="object-cover shadow-lg rounded-lg h-40 w-72"
+          class="object-contain shadow-lg rounded-lg w-72"
         />
       </a>
       <div class="mt-4">


### PR DESCRIPTION
I noticed images are getting cutoff/cropped on the showcase page. This PR will remove the cover and height properties.

Before:
![image](https://user-images.githubusercontent.com/6100364/165885789-d256ecd6-3cef-4497-bf43-1c43652377ef.png)

After:
![image](https://user-images.githubusercontent.com/6100364/165885812-dbf56db5-db46-47c4-b5dc-c30347e7cb9a.png)
