### PR TITLE
fix: add missing labels to y axes

### DIFF
--- a/routes/benchmarks.tsx
+++ b/routes/benchmarks.tsx
@@ -277,6 +277,7 @@ export default function Benchmarks({ url, data }: PageProps<Data>) {
                   columns={benchData.threadCount.filter(({ name }) =>
                     !typescriptBenches.includes(name)
                   )}
+                  yLabel="threads"
                 />
                 <p class={tw`mt-1`}>
                   How many threads various programs use. Smaller is better.
@@ -295,6 +296,7 @@ export default function Benchmarks({ url, data }: PageProps<Data>) {
                   columns={benchData.syscallCount.filter(({ name }) =>
                     !typescriptBenches.includes(name)
                   )}
+                  yLabel="syscalls"
                 />
                 <p class={tw`mt-1`}>
                   How many total syscalls are performed when executing a given
@@ -449,7 +451,10 @@ export default function Benchmarks({ url, data }: PageProps<Data>) {
                     Cargo Dependencies
                   </h5>
                 </a>{" "}
-                <BenchmarkChart columns={benchData.cargoDeps} />
+                <BenchmarkChart
+                  columns={benchData.cargoDeps}
+                  yLabel="dependencies"
+                />
               </div>
             </div>
             <div class={tw`mt-20`}>


### PR DESCRIPTION
On [benchmarks](https://deno.land/benchmarks), adding a label to y axes for:

* Thread count
* Syscall count and
* Cargo Dependencies

Currently displays "undefined".
