### PR TITLE
ci: type check only local files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: deno lint
 
       - name: Type Check
-        run: deno check --remote main.ts
+        run: deno check main.ts
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Main CI is failing with remote type errors, which we can't fix on our side. https://github.com/denoland/dotland/runs/6913536201?check_suite_focus=true

I think local type checking is enough for the CI for this repository. What do you think @crowlKats ?