### PR TITLE
Fix icon size and margin

### DIFF
--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -314,10 +314,10 @@ export function Menu(props: { title?: string }) {
   );
 }
 
-export function Star(props: { class?: string, title?: string }) {
+export function Star(props: { class?: string; title?: string }) {
   return (
     <svg
-      class={tw`text-gray-400 w-5 h-5 ${props.class ?? ""}`}
+      class={tw`w-5 h-5 ${props.class ?? ""}`}
       fill="currentColor"
       viewBox="0 0 20 20"
     >

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -314,10 +314,10 @@ export function Menu(props: { title?: string }) {
   );
 }
 
-export function Star(props: { title?: string }) {
+export function Star(props: { class?: string, title?: string }) {
   return (
     <svg
-      class={tw`ml-1 text-gray-400 w-5 h-5`}
+      class={tw`text-gray-400 w-5 h-5 ${props.class ?? ""}`}
       fill="currentColor"
       viewBox="0 0 20 20"
     >

--- a/routes/x/index.tsx
+++ b/routes/x/index.tsx
@@ -413,7 +413,7 @@ function ModuleList({
                     <div class={tw`text-gray-400`}>
                       {meta.starCount}
                     </div>
-                    <Icons.Star title="star" />
+                    <Icons.Star class="ml-1" title="star" />
                   </div>
                 )}
                 <div>

--- a/routes/x/index.tsx
+++ b/routes/x/index.tsx
@@ -413,7 +413,7 @@ function ModuleList({
                     <div class={tw`text-gray-400`}>
                       {meta.starCount}
                     </div>
-                    <Icons.Star class="ml-1" title="star" />
+                    <Icons.Star class="ml-1 text-gray-400" title="star" />
                   </div>
                 )}
                 <div>

--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -203,11 +203,11 @@ function ModuleView({
                     >
                     </div>
                     <div class={tw`mt-3 flex items-center py-0.5`}>
-                      <Icons.GitHub class="mr-2 inline text-gray-200" />
+                      <Icons.GitHub class="mr-2 w-5 h-5 inline text-gray-200" />
                       <div class={tw`w-4/5 sm:w-2/3 bg-gray-100 h-4`}></div>
                     </div>
                     <div class={tw`mt-2 flex items-center py-0.5`}>
-                      <Icons.Star title="GitHub Stars" />
+                      <Icons.Star class="mr-2" title="GitHub Stars" />
                       <div class={tw`w-1/6 sm:w-1/5 bg-gray-100 h-4`}></div>
                     </div>
                   </>
@@ -220,7 +220,7 @@ function ModuleView({
                       {emojify(moduleMeta.description ?? "")}
                     </div>
                     <div class={tw`mt-3 flex items-center`}>
-                      <Icons.GitHub class="mr-2 inline text-gray-700" />
+                      <Icons.GitHub class="mr-2 w-5 h-5 inline text-gray-700" />
                       <a
                         class={tw`link`}
                         href={`https://github.com/${versionMeta.uploadOptions.repository}`}
@@ -229,7 +229,7 @@ function ModuleView({
                       </a>
                     </div>
                     <div class={tw`mt-2 flex items-center`}>
-                      <Icons.Star title="GitHub stars" />
+                      <Icons.Star class="mr-2" title="GitHub Stars" />
                       <div>{moduleMeta.star_count}</div>
                     </div>
                   </>


### PR DESCRIPTION
Bug introduced in #2179:

<img width="286" alt="image" src="https://user-images.githubusercontent.com/44045911/174140966-95df03dd-6368-4628-b20a-7eb768b84c6c.png">

- The sizes of the three icons are inconsistent
- Star icon has wrong margin

[What it used to look like](https://dotland-31pv120xdm80.deno.dev/std@0.144.0):

<img width="281" alt="image" src="https://user-images.githubusercontent.com/44045911/174141142-4c844075-2195-467d-b053-4350adb5c4cb.png">
