### PR TITLE
Redirect to codeview directly when line of code provided

### DIFF
--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -572,7 +572,7 @@ export const handler: Handlers<Data> = {
 
     const ln = extractAltLineNumberReference(url.toString());
     if (ln) {
-      return Response.redirect(`${ln.rest}#L${ln.line}`, 302);
+      return Response.redirect(`${ln.rest}?codeview=#L${ln.line}`, 302);
     }
 
     version = decodeURIComponent(params.version);

--- a/tests/handler_test.ts
+++ b/tests/handler_test.ts
@@ -113,7 +113,7 @@ Deno.test({
 
 Deno.test({
   name:
-    "/std@0.127.0/fs/mod.ts:5:3 with Accept: 'text/html' responds with line number redirect",
+    "/std@0.127.0/fs/mod.ts:5:3 with Accept: 'text/html' responds with codeview and line number redirect",
   async fn() {
     const res = await handleRequest(
       new Request("https://deno.land/std@0.127.0/fs/mod.ts:5:3", {

--- a/tests/handler_test.ts
+++ b/tests/handler_test.ts
@@ -121,7 +121,7 @@ Deno.test({
       }),
     );
     assertEquals(res.status, 302);
-    assert(res.headers.get("Location")?.includes("/std@0.127.0/fs/mod.ts#L5"));
+    assert(res.headers.get("Location")?.includes("/std@0.127.0/fs/mod.ts?codeview=#L5"));
     await res.text();
   },
 });

--- a/tests/handler_test.ts
+++ b/tests/handler_test.ts
@@ -121,7 +121,11 @@ Deno.test({
       }),
     );
     assertEquals(res.status, 302);
-    assert(res.headers.get("Location")?.includes("/std@0.127.0/fs/mod.ts?codeview=#L5"));
+    assert(
+      res.headers.get("Location")?.includes(
+        "/std@0.127.0/fs/mod.ts?codeview=#L5",
+      ),
+    );
     await res.text();
   },
 });


### PR DESCRIPTION
Fix the redirect link to show the code directly.
This will be helpful when click the code link in error trace. :)

## previous behavior
https://deno.land/x/pbkit@v0.0.46/README.md:1:1
redirects to
https://deno.land/x/pbkit@v0.0.46/README.md#L1

## fixed behavior
https://deno.land/x/pbkit@v0.0.46/README.md:1:1
redirects to
https://deno.land/x/pbkit@v0.0.46/README.md?codeview=#L1
