### PR TITLE
use break-word instead of break-all

### DIFF
--- a/components/InlineCode.tsx
+++ b/components/InlineCode.tsx
@@ -10,7 +10,7 @@ export function InlineCode(
   return (
     <code
       class={tw
-        `py-1 px-2 font-mono bg-gray-100 text-sm break-all rounded-[6px]`}
+        `py-1 px-2 font-mono bg-gray-100 text-sm break-word rounded-[6px]`}
       id={props.id}
     >
       {props.children}


### PR DESCRIPTION
I noticed that the inline code can jump to a new line after each letter.
Perhaps you have your reasons for this, but in my opinion this is not so nice to look at and hard to read.

Index:
<img width="564" alt="Screenshot 2022-06-24 at 11 12 29" src="https://user-images.githubusercontent.com/35741000/175504474-eaab34f4-b951-4146-886d-84965b1aaeb7.png">

Benchmarks:
<img width="549" alt="Screenshot 2022-06-24 at 11 17 09" src="https://user-images.githubusercontent.com/35741000/175504989-b376b7ba-7126-42f3-a183-26dea439062e.png">

