### PR TITLE
fix: don't wrap display-toggle

### DIFF
--- a/components/FileDisplay.tsx
+++ b/components/FileDisplay.tsx
@@ -48,7 +48,11 @@ export function FileDisplay(props: {
           }`}
       >
         <div class={tw`flex items-center`}>
-          {isReadme(filename) && <Icons.LightOpenBook />}
+          {isReadme(filename) && (
+            <span class={tw`hidden sm:inline-block`}>
+              <Icons.LightOpenBook />
+            </span>
+          )}
           <span class={tw`font-medium`}>
             {props.canonicalPath === props.url.pathname
               ? filename
@@ -68,13 +72,15 @@ export function FileDisplay(props: {
             )}
             {props.repositoryURL &&
               (
-                <a href={props.repositoryURL} class={tw`link ml-4`}>
+                <a href={props.repositoryURL} class={tw`link ml-2 sm:ml-4`}>
                   Repository
                 </a>
               )}
           </div>
           {hasToggle && (
-            <div class={tw`inline-block ml-4 inline-flex shadow-sm rounded-md`}>
+            <div
+              class={tw`inline-flex ml-4 flex-nowrap shadow-sm rounded-md`}
+            >
               <a
                 href={searchDoc.href}
                 class={tw


### PR DESCRIPTION
This prevents the code/preview toggle from wrapping on smaller screens by hiding the README book icon on screen sizes under tw's `sm` breakpoint.

Before:

![image](https://user-images.githubusercontent.com/45368713/175513729-a840cc69-500a-4b4f-9d6d-e15281e92b10.png)

After:

![image](https://user-images.githubusercontent.com/45368713/175513704-3fdfc576-fad0-4c0d-8c26-22e7e651d298.png)


