### PR TITLE
chore: remove unnecessary `catch`

### DIFF
--- a/util/ga_utils.ts
+++ b/util/ga_utils.ts
@@ -179,8 +179,6 @@ function ga4(
     }
 
     await report.send();
-  }).catch((err) => {
-    console.error(`Internal error: ${err}`);
   });
 }
 


### PR DESCRIPTION
This is because `report.send` won't throw errors.[1]

[1] https://github.com/denoland/ga4/blob/04a1ce209116f158b5ef1658b957bdb109db68ed/mod.ts#L227