### PR TITLE
fix: news bar focus and hover styles

### DIFF
--- a/components/HelloBar.tsx
+++ b/components/HelloBar.tsx
@@ -10,7 +10,11 @@ export function HelloBar(props: {
 }) {
   return (
     <div class={tw`text-center bg-black text-white p-1`}>
-      <a href={props.to} target="_blank" class={tw`inline-block p-1 hover:text-underline`}>
+      <a
+        href={props.to}
+        target="_blank"
+        class={tw`inline-block p-1 hover:text-underline`}
+      >
         {props.children}
       </a>
     </div>

--- a/components/HelloBar.tsx
+++ b/components/HelloBar.tsx
@@ -9,8 +9,8 @@ export function HelloBar(props: {
   children: ComponentChildren;
 }) {
   return (
-    <div class={tw`text-center bg-black text-white`}>
-      <a href={props.to} target="_blank" class={tw`h-full w-full block p-2`}>
+    <div class={tw`text-center bg-black text-white p-1`}>
+      <a href={props.to} target="_blank" class={tw`inline-block p-1 hover:text-underline`}>
         {props.children}
       </a>
     </div>


### PR DESCRIPTION
* Make news bar focusable
* Add hover styles

**Focus:**
![Screen Shot 2022-06-30 at 21 38 29](https://user-images.githubusercontent.com/47859603/176763301-4af73662-090e-4134-b370-91d07500be5c.png)

**Hover**:
![Screen Shot 2022-06-30 at 21 36 57](https://user-images.githubusercontent.com/47859603/176763400-df187fbd-9b4d-473a-8f7b-2f67fe6ab0d9.png)

Closes #2223.