### PR TITLE
fix: restore background of code blocks

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -146,7 +146,7 @@ export function CodeBlock(
       code={code}
       language={language}
       disablePrefixes={disablePrefixes}
-      class={tw`p-4`}
+      class={tw`p-4 bg-gray-100 rounded-lg`}
       url={url}
     />
   );


### PR DESCRIPTION
The background color of code blocks was dropped in #2155. This PR restores it.

Before
<img width="650" alt="スクリーンショット 2022-07-22 23 49 45" src="https://user-images.githubusercontent.com/613956/180465240-771aad6c-027b-4701-8528-49f6084e5f88.png">

After
<img width="642" alt="スクリーンショット 2022-07-22 23 48 35" src="https://user-images.githubusercontent.com/613956/180465303-89d192ea-3d06-477a-8987-aa7a8193c91e.png">
