### PR TITLE
fix: hover:underline only on url part

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -103,6 +103,7 @@ export function RawCodeBlock({
 
                 if (token.types.includes("string")) {
                   try {
+                    const quote = token.content[0];
                     const urlContent = token.content.slice(1, -1);
                     const res = new URL(
                       urlContent,
@@ -112,13 +113,19 @@ export function RawCodeBlock({
                     );
 
                     return (
-                      <a
-                        className={tw`hover:underline` + " token " +
+                      <span
+                        className={"token " +
                           token.types.join(" ")}
-                        href={res.href + "?code"}
                       >
-                        {token.content}
-                      </a>
+                        {quote}
+                        <a
+                          className={tw`hover:underline`}
+                          href={res.href + "?code"}
+                        >
+                          {urlContent}
+                        </a>
+                        {quote}
+                      </span>
                     );
                   } catch (e) {
                     // ignore


### PR DESCRIPTION
This PR changes the underlined part of the url.

Currently we underline the url in import statement including quote chars.

Current
<img width="614" alt="スクリーンショット 2022-07-25 20 05 01" src="https://user-images.githubusercontent.com/613956/180763381-df352701-4893-42cd-aacd-9195192a5f9b.png">

This PR excludes quote chars from underlined part.

This PR
<img width="615" alt="スクリーンショット 2022-07-25 20 05 22" src="https://user-images.githubusercontent.com/613956/180763403-2f7170db-d8b1-4ac2-a5d8-cf478b708255.png">
