### PR TITLE
fix(CodeBlock): link only full url or relative path

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -7,7 +7,11 @@ import { tw } from "@twind";
 import { Prism } from "@/util/prism_utils.ts";
 import { escape as htmlEscape } from "$he";
 import { normalizeTokens } from "@/util/prism_utils.ts";
-import { fileTypeFromURL, filetypeIsJS } from "../util/registry_utils.ts";
+import {
+  extractLinkUrl,
+  fileTypeFromURL,
+  filetypeIsJS,
+} from "../util/registry_utils.ts";
 
 export interface CodeBlockProps {
   code: string;
@@ -102,16 +106,12 @@ export function RawCodeBlock({
                 }
 
                 if (token.types.includes("string")) {
-                  try {
-                    const quote = token.content[0];
-                    const urlContent = token.content.slice(1, -1);
-                    const res = new URL(
-                      urlContent,
-                      filetypeIsJS(fileTypeFromURL(urlContent))
-                        ? url
-                        : undefined,
-                    );
-
+                  const result = extractLinkUrl(
+                    token.content,
+                    url.origin + url.pathname,
+                  );
+                  if (result) {
+                    const [href, specifier, quote] = result;
                     return (
                       <span
                         className={"token " +
@@ -120,15 +120,13 @@ export function RawCodeBlock({
                         {quote}
                         <a
                           className={tw`hover:underline`}
-                          href={res.href + "?code"}
+                          href={href + "?code"}
                         >
-                          {urlContent}
+                          {specifier}
                         </a>
                         {quote}
                       </span>
                     );
-                  } catch (e) {
-                    // ignore
                   }
                 }
                 return (

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -769,3 +769,35 @@ export function extractAltLineNumberReference(
     line: parseInt(matches[2]),
   };
 }
+
+/** Matches to https://example.com/foo.ts type string */
+const RE_IS_DENO_LAND_SCRIPT =
+  /^https:\/\/deno\.land\/.*\.(ts|js|tsx|jsx|mts|cts|mjs|cjs)$/;
+const RE_IS_SCRIPT = /\.(ts|js|tsx|jsx|mts|cts|mjs|cjs)$/;
+/** Matches to ./path/to/foo.ts type string */
+const RE_IS_RELATIVE_PATH_SCRIPT =
+  /^\.\.?\/.*\.(ts|js|tsx|jsx|mts|cts|mjs|cjs)$/;
+
+/** Tries to extract link target url from the given target specifier and baseUrl.
+ * The return value is 3-tuple of the link url, the specifier, and the quote character.
+ * Returns undefined if the target isn't url. */
+export function extractLinkUrl(
+  target: string,
+  baseUrl: string,
+): [string, string, string] | undefined {
+  const quote = target[0];
+  const specifier = target.slice(1, -1);
+  if (RE_IS_DENO_LAND_SCRIPT.test(specifier)) {
+    return [specifier, specifier, quote];
+  } else if (
+    RE_IS_RELATIVE_PATH_SCRIPT.test(specifier) &&
+    RE_IS_SCRIPT.test(baseUrl)
+  ) {
+    try {
+      return [new URL(specifier, baseUrl).href, specifier, quote];
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}

--- a/util/registry_utils_test.ts
+++ b/util/registry_utils_test.ts
@@ -290,5 +290,8 @@ Deno.test("extractLinkUrl", () => {
   assertEquals(extractLinkUrl(`"https://example.com/foo.ts"`, ""), undefined);
 
   // Doesn't link relative path if the base url is not script
-  assertEquals(extractLinkUrl(`"./foo.ts"`, "https://deno.land/README.md"), undefined);
+  assertEquals(
+    extractLinkUrl(`"./foo.ts"`, "https://deno.land/README.md"),
+    undefined,
+  );
 });

--- a/util/registry_utils_test.ts
+++ b/util/registry_utils_test.ts
@@ -1,6 +1,7 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
 import {
+  extractLinkUrl,
   fileNameFromURL,
   fileTypeFromURL,
   findRootReadme,
@@ -241,4 +242,53 @@ Deno.test("isReadme", () => {
   for (const [path, expectedToBeReadme] of tests) {
     assertEquals([path, isReadme(path)], [path, expectedToBeReadme]);
   }
+});
+
+Deno.test("extractLinkUrl", () => {
+  assertEquals(
+    extractLinkUrl(`"https://deno.land/std/foo/bar.ts"`, "")![0],
+    "https://deno.land/std/foo/bar.ts",
+  );
+  assertEquals(
+    extractLinkUrl(`"https://deno.land/std/foo/bar.js"`, "")![0],
+    "https://deno.land/std/foo/bar.js",
+  );
+  assertEquals(
+    extractLinkUrl(`"https://deno.land/std/foo/bar.tsx"`, "")![0],
+    "https://deno.land/std/foo/bar.tsx",
+  );
+  assertEquals(
+    extractLinkUrl(`"https://deno.land/std/foo/bar.jsx"`, "")![0],
+    "https://deno.land/std/foo/bar.jsx",
+  );
+  assertEquals(
+    extractLinkUrl(`"https://deno.land/std/foo/bar.mts"`, "")![0],
+    "https://deno.land/std/foo/bar.mts",
+  );
+  assertEquals(
+    extractLinkUrl(`"https://deno.land/std/foo/bar.cts"`, "")![0],
+    "https://deno.land/std/foo/bar.cts",
+  );
+  assertEquals(
+    extractLinkUrl(`"https://deno.land/std/foo/bar.mjs"`, "")![0],
+    "https://deno.land/std/foo/bar.mjs",
+  );
+  assertEquals(
+    extractLinkUrl(`"https://deno.land/std/foo/bar.cjs"`, "")![0],
+    "https://deno.land/std/foo/bar.cjs",
+  );
+  assertEquals(
+    extractLinkUrl(`"./qux.ts"`, "https://deno.land/std/foo/bar/baz.ts")![0],
+    "https://deno.land/std/foo/bar/qux.ts",
+  );
+  assertEquals(
+    extractLinkUrl(`"../quux.ts"`, "https://deno.land/std/foo/bar/baz.ts")![0],
+    "https://deno.land/std/foo/quux.ts",
+  );
+
+  // Doesn't link to the external site's url
+  assertEquals(extractLinkUrl(`"https://example.com/foo.ts"`, ""), undefined);
+
+  // Doesn't link relative path if the base url is not script
+  assertEquals(extractLinkUrl(`"./foo.ts"`, "https://deno.land/README.md"), undefined);
 });


### PR DESCRIPTION
This PR improves the algorithm to link the specifier in code blocks, and also adds test cases to it.

This PR particularly prevents linking the below part in https://deno.land/std@0.149.0/collections/mod.ts?code#L12
<img width="420" alt="スクリーンショット 2022-07-27 14 18 57" src="https://user-images.githubusercontent.com/613956/181167309-b55079e8-cd60-4bd5-8a15-fd19eb4fb414.png">

