### PR TITLE
chore: pin esm.sh version for dependencies

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -4,20 +4,20 @@
     "@twind": "./util/twind.ts",
 
     "$fresh/": "https://fresh.deno.dev/@1.0.0-rc.4/",
-    "preact": "https://esm.sh/preact@10.8.1",
+    "preact": "https://esm.sh/preact@10.8.1?pin=v87",
     "preact/": "https://esm.sh/preact@10.8.1/",
-    "preact-render-to-string": "https://esm.sh/preact-render-to-string@5.1.20?deps=preact@10.8.1",
-    "twind": "https://esm.sh/twind@0.16.17",
+    "preact-render-to-string": "https://esm.sh/preact-render-to-string@5.1.20?deps=preact@10.8.1&pin=v87",
+    "twind": "https://esm.sh/twind@0.16.17?pin=v87",
     "twind/": "https://esm.sh/twind@0.16.17/",
-    "$prism": "https://esm.sh/prismjs@1.27.0",
+    "$prism": "https://esm.sh/prismjs@1.27.0?pin=v87",
     "$prism/": "https://esm.sh/prismjs@1.27.0/",
-    "$twas": "https://esm.sh/twas@2.1.2",
+    "$twas": "https://esm.sh/twas@2.1.2?pin=v87",
     "$emoji": "https://deno.land/x/emoji@0.1.2/mod.ts",
     "$std/": "https://deno.land/std@0.143.0/",
     "$gfm": "https://deno.land/x/gfm@0.1.20/mod.ts",
-    "$tiny-version-compare": "https://esm.sh/tiny-version-compare@3.0.1",
+    "$tiny-version-compare": "https://esm.sh/tiny-version-compare@3.0.1?pin=v87",
     "$fuse/": "https://deno.land/x/fuse@v6.4.1/dist/",
-    "$he": "https://esm.sh/he@1.2.0",
+    "$he": "https://esm.sh/he@1.2.0?pin=v87",
     "$pretty_bytes": "https://deno.land/x/pretty_bytes@v1.0.5/mod.ts",
     "$router": "https://crux.land/router@0.0.12",
     "$ga4": "https://raw.githubusercontent.com/denoland/ga4/main/mod.ts",
@@ -25,6 +25,6 @@
     "$oak_commons": "https://deno.land/x/oak_commons@0.1.1/negotiation.ts",
     "$doc_components/": "https://raw.githubusercontent.com/denoland/doc_components/cbcaaaf00508c9bd64c3c2ebb4d9899659168a44/",
     "$deno_doc/": "https://deno.land/x/deno_doc@v0.34.0/lib/",
-    "$algolia": "https://esm.sh/algoliasearch@4.13.1"
+    "$algolia": "https://esm.sh/algoliasearch@4.13.1?pin=v87"
   }
 }


### PR DESCRIPTION
The latest version appears to have broken something and is blocking the v1.24.1 release.