### PR TITLE
fix: better instatus badge

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -71,11 +71,11 @@ export function Footer() {
           <div class={tw`space-y-5 w-60`}>
             <iframe
               src="https://denostatus.com/embed-status/light-sm"
-              height="42"
+              height="41"
               frameBorder="0"
               scrolling="no"
               style="border: none;"
-              class={tw`w-full focus:outline-none`}
+              class={tw`w-full rounded-lg focus:outline-none`}
             />
 
             <div class={tw`space-y-2.5 lg:space-y-4.5`}>


### PR DESCRIPTION
Fixes the instatus badge in the footer (for the users who set OS default dark theme.)

Before
<img width="304" alt="スクリーンショット 2022-08-01 15 01 24" src="https://user-images.githubusercontent.com/613956/182082341-513596fc-7d8b-4221-8fb1-ab4ca10aaf23.png">

After
<img width="316" alt="スクリーンショット 2022-08-01 15 00 48" src="https://user-images.githubusercontent.com/613956/182082362-14e5e5a4-dfdb-4da7-9585-9d0bdd923af1.png">

closes #2323 
