### PR TITLE
a11y : Fix search tab underline

### DIFF
--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -234,9 +234,8 @@ export default function GlobalSearch() {
                 {kinds.map((k) => (
                   <button
                     class={tw`px-2 rounded-md leading-relaxed hover:(bg-gray-100 text-main) ${
-                      k === kind
-                        ? "border-black border-b-2 rounded-none"
-                        : ""} ${k === kind ? "text-black" : "text-gray-500"}`}
+                      k === kind ? "border-black border-b-2 rounded-none" : ""
+                    } ${k === kind ? "text-black" : "text-gray-500"}`}
                     onClick={() => {
                       setKind(k);
                       setPage(0);

--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -234,8 +234,10 @@ export default function GlobalSearch() {
                 {kinds.map((k) => (
                   <button
                     class={tw`px-2 rounded-md leading-relaxed hover:(bg-gray-100 text-main) ${
-                      k === kind ? "border-black border-b-2 rounded-none" : ""
-                    } ${k === kind ? "text-black" : "text-gray-500"}`}
+                      k === kind
+                        ? "border-black border-b-2 rounded-none text-black"
+                        : "text-gray-500"
+                    }`}
                     onClick={() => {
                       setKind(k);
                       setPage(0);

--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -234,13 +234,8 @@ export default function GlobalSearch() {
                 {kinds.map((k) => (
                   <button
                     class={tw`px-2 rounded-md leading-relaxed hover:(bg-gray-100 text-main) ${
-                      // TODO: use border instead
                       k === kind
-                        ? css({
-                          "text-decoration-line": "underline",
-                          "text-underline-offset": "6px",
-                          "text-decoration-thickness": "2px",
-                        })
+                        ? "border-black border-b-2 rounded-none"
                         : ""} ${k === kind ? "text-black" : "text-gray-500"}`}
                     onClick={() => {
                       setKind(k);

--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -232,19 +232,21 @@ export default function GlobalSearch() {
 
               <div class={tw`flex gap-3 mt-2`}>
                 {kinds.map((k) => (
-                  <button
-                    class={tw`px-2 rounded-md leading-relaxed hover:(bg-gray-100 text-main) ${
-                      k === kind
-                        ? "border-black border-b-2 rounded-none text-black"
-                        : "text-gray-500"
-                    }`}
-                    onClick={() => {
-                      setKind(k);
-                      setPage(0);
-                    }}
+                  <div
+                    class={tw`${k === kind ? "border-black border-b-2" : ""}`}
                   >
-                    {k}
-                  </button>
+                    <button
+                      class={tw`px-2 rounded-md leading-relaxed hover:(bg-gray-100 text-main) ${
+                        k === kind ? "text-black" : "text-gray-500"
+                      }`}
+                      onClick={() => {
+                        setKind(k);
+                        setPage(0);
+                      }}
+                    >
+                      {k}
+                    </button>
+                  </div>
                 ))}
               </div>
             </div>


### PR DESCRIPTION
Closes https://github.com/denoland/dotland/issues/2354

* Remove use of CSS({}) and `text-decoration`
* Use bottom-border to give an underline

Works on Chrome, Firefox, Opera


![image](https://user-images.githubusercontent.com/7072946/185210172-27014585-1aec-403e-a22b-54e053e5b0c5.png)
