### PR TITLE
feat: publish search click events

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,7 +1,6 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
 /** @jsx h */
-/** @jsxFrag Fragment */
 import { h } from "preact";
 
 import { apply, css, tw } from "@twind";

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,7 +2,7 @@
 
 /** @jsx h */
 /** @jsxFrag Fragment */
-import { Fragment, h } from "preact";
+import { h } from "preact";
 
 import { apply, css, tw } from "@twind";
 import * as Icons from "./Icons.tsx";
@@ -18,14 +18,18 @@ const entries = [
   { href: "/x", content: "Third Party Modules" },
 ] as const;
 
+type ContentTypes = (typeof entries)[number]["content"];
+
 export function Header({
   selected,
   main,
   manual,
+  userToken,
 }: {
-  selected?: (typeof entries)[number]["content"];
+  selected?: ContentTypes;
   main?: boolean;
   manual?: boolean;
+  userToken: string;
 }) {
   return (
     <div
@@ -62,7 +66,7 @@ export function Header({
               <img class={tw`h-full w-full`} src="/logo.svg" alt="Deno Logo" />
             </a>
 
-            <GlobalSearch />
+            <GlobalSearch userToken={userToken} />
 
             <label
               tabIndex={0}

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -4,24 +4,25 @@
 
 import * as $0 from "./routes/_404.tsx";
 import * as $1 from "./routes/_app.tsx";
-import * as $2 from "./routes/add_module.tsx";
-import * as $3 from "./routes/artwork.tsx";
-import * as $4 from "./routes/badge.ts";
-import * as $5 from "./routes/benchmarks.tsx";
-import * as $6 from "./routes/completions/config.ts";
-import * as $7 from "./routes/completions/v1.ts";
-import * as $8 from "./routes/gfm.css.ts";
-import * as $9 from "./routes/index.tsx";
-import * as $10 from "./routes/install.ts";
-import * as $11 from "./routes/legacy_redirects/posts.ts";
-import * as $12 from "./routes/legacy_redirects/v1.ts";
-import * as $13 from "./routes/manual.tsx";
-import * as $14 from "./routes/showcase.tsx";
-import * as $15 from "./routes/status.tsx";
-import * as $16 from "./routes/std.tsx";
-import * as $17 from "./routes/translations.tsx";
-import * as $18 from "./routes/x/index.tsx";
-import * as $19 from "./routes/x/module.tsx";
+import * as $2 from "./routes/_middleware.ts";
+import * as $3 from "./routes/add_module.tsx";
+import * as $4 from "./routes/artwork.tsx";
+import * as $5 from "./routes/badge.ts";
+import * as $6 from "./routes/benchmarks.tsx";
+import * as $7 from "./routes/completions/config.ts";
+import * as $8 from "./routes/completions/v1.ts";
+import * as $9 from "./routes/gfm.css.ts";
+import * as $10 from "./routes/index.tsx";
+import * as $11 from "./routes/install.ts";
+import * as $12 from "./routes/legacy_redirects/posts.ts";
+import * as $13 from "./routes/legacy_redirects/v1.ts";
+import * as $14 from "./routes/manual.tsx";
+import * as $15 from "./routes/showcase.tsx";
+import * as $16 from "./routes/status.tsx";
+import * as $17 from "./routes/std.tsx";
+import * as $18 from "./routes/translations.tsx";
+import * as $19 from "./routes/x/index.tsx";
+import * as $20 from "./routes/x/module.tsx";
 import * as $$0 from "./islands/AddModule.tsx";
 import * as $$1 from "./islands/GlobalSearch.tsx";
 import * as $$2 from "./islands/HelloBar.tsx";
@@ -31,24 +32,25 @@ const manifest = {
   routes: {
     "./routes/_404.tsx": $0,
     "./routes/_app.tsx": $1,
-    "./routes/add_module.tsx": $2,
-    "./routes/artwork.tsx": $3,
-    "./routes/badge.ts": $4,
-    "./routes/benchmarks.tsx": $5,
-    "./routes/completions/config.ts": $6,
-    "./routes/completions/v1.ts": $7,
-    "./routes/gfm.css.ts": $8,
-    "./routes/index.tsx": $9,
-    "./routes/install.ts": $10,
-    "./routes/legacy_redirects/posts.ts": $11,
-    "./routes/legacy_redirects/v1.ts": $12,
-    "./routes/manual.tsx": $13,
-    "./routes/showcase.tsx": $14,
-    "./routes/status.tsx": $15,
-    "./routes/std.tsx": $16,
-    "./routes/translations.tsx": $17,
-    "./routes/x/index.tsx": $18,
-    "./routes/x/module.tsx": $19,
+    "./routes/_middleware.ts": $2,
+    "./routes/add_module.tsx": $3,
+    "./routes/artwork.tsx": $4,
+    "./routes/badge.ts": $5,
+    "./routes/benchmarks.tsx": $6,
+    "./routes/completions/config.ts": $7,
+    "./routes/completions/v1.ts": $8,
+    "./routes/gfm.css.ts": $9,
+    "./routes/index.tsx": $10,
+    "./routes/install.ts": $11,
+    "./routes/legacy_redirects/posts.ts": $12,
+    "./routes/legacy_redirects/v1.ts": $13,
+    "./routes/manual.tsx": $14,
+    "./routes/showcase.tsx": $15,
+    "./routes/status.tsx": $16,
+    "./routes/std.tsx": $17,
+    "./routes/translations.tsx": $18,
+    "./routes/x/index.tsx": $19,
+    "./routes/x/module.tsx": $20,
   },
   islands: {
     "./islands/AddModule.tsx": $$0,

--- a/import_map.json
+++ b/import_map.json
@@ -27,6 +27,7 @@
     "$deno_doc/": "https://deno.land/x/deno_doc@v0.34.0/lib/",
     "$canvas-confetti": "https://esm.sh/canvas-confetti@1.5.1",
     "$algolia": "https://esm.sh/algoliasearch@4.13.1",
+    "$algolia/client-search": "https://esm.sh/@algolia/client-search@4.14.2?pin=v90",
     "$algolia/requester-fetch": "https://esm.sh/@algolia/requester-fetch@4.14.2?pin=v90"
   }
 }

--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -4,6 +4,10 @@
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
 import algoliasearch from "$algolia";
+import type {
+  MultipleQueriesQuery,
+  SearchResponse,
+} from "$algolia/client-search";
 import { createFetchRequester } from "$algolia/requester-fetch";
 import { IS_BROWSER } from "$fresh/runtime.ts";
 import { css, tw } from "@twind";
@@ -11,6 +15,7 @@ import { useEffect, useState } from "preact/hooks";
 import * as Icons from "@/components/Icons.tsx";
 import type { DocNode } from "$deno_doc/types.d.ts";
 import { colors, docNodeKindMap } from "@/components/symbol_kind.tsx";
+import { searchClick } from "@/util/search_insights_utils.ts";
 import { ComponentChildren } from "preact";
 
 // Lazy load a <dialog> polyfill.
@@ -21,12 +26,18 @@ if (IS_BROWSER && window.HTMLDialogElement === "undefined") {
   );
 }
 
+const MODULE_INDEX = "modules";
+const SYMBOL_INDEX = "doc_nodes";
+const MANUAL_INDEX = "manual";
+
 const kinds = [
   "All",
   "Manual",
   "Modules",
   "Symbols",
 ] as const;
+
+type SearchKinds = typeof kinds[number];
 
 const symbolKinds = {
   "Namespaces": "namespace",
@@ -37,6 +48,8 @@ const symbolKinds = {
   "Interfaces": "interface",
   "Type Aliases": "typeAlias",
 } as const;
+
+type SymbolKinds = keyof typeof symbolKinds;
 
 interface ManualSearchResult {
   docPath: string;
@@ -50,23 +63,46 @@ interface ModuleSearchResult {
   description: string;
 }
 
+interface SearchResults<ResultItem> {
+  queryID?: string;
+  hits: (ResultItem & { objectID: string })[];
+  hitsPerPage: number;
+  page: number;
+}
+
+interface Results {
+  manual?: SearchResults<ManualSearchResult>;
+  modules?: SearchResults<ModuleSearchResult>;
+  symbols?: SearchResults<DocNode>;
+}
+
+function toSearchResults<ResultItem>(
+  // deno-lint-ignore no-explicit-any
+  response: SearchResponse<any>[],
+  index: string,
+): SearchResults<ResultItem> | undefined {
+  const result = response.find((res) => res.index === index);
+  if (result) {
+    const { queryID, hits, hitsPerPage, page } = result;
+    return { queryID, hits, hitsPerPage, page };
+  }
+}
+
+function getPosition(results: SearchResults<unknown>, index: number): number {
+  return (results.hitsPerPage * results.page) + index + 1;
+}
+
 /** Search Deno documentation, symbols, or modules. */
-export default function GlobalSearch() {
+export default function GlobalSearch({ userToken }: { userToken?: string }) {
   const [showModal, setShowModal] = useState(false);
   const [input, setInput] = useState("");
 
-  const [results, setResults] = useState<
-    {
-      manual?: Array<ManualSearchResult>;
-      modules?: Array<ModuleSearchResult>;
-      symbols?: Array<DocNode>;
-    } | null
-  >(null);
-  const [kind, setKind] = useState<typeof kinds[number]>("All");
+  const [results, setResults] = useState<Results | null>(null);
+  const [kind, setKind] = useState<SearchKinds>("All");
   const [page, setPage] = useState<number>(0);
   const [totalPages, setTotalPages] = useState<number>(1);
   const [symbolKindsToggle, setSymbolKindsToggle] = useState<
-    Record<(keyof typeof symbolKinds), boolean>
+    Record<SymbolKinds, boolean>
   >({
     "Namespaces": true,
     "Classes": true,
@@ -108,15 +144,16 @@ export default function GlobalSearch() {
 
     setResults(null);
 
-    const queries = [];
+    const queries: MultipleQueriesQuery[] = [];
 
     if (kind === "Manual" || kind === "All") {
       queries.push({
-        indexName: "manual",
+        indexName: MANUAL_INDEX,
         query: input || "Introduction",
         params: {
           page: page,
           hitsPerPage: kind === "All" ? 5 : 10,
+          clickAnalytics: true,
           filters: "kind:paragraph",
         },
       });
@@ -124,11 +161,12 @@ export default function GlobalSearch() {
 
     if (kind === "Symbols" || kind === "All") {
       queries.push({
-        indexName: "doc_nodes",
+        indexName: SYMBOL_INDEX,
         query: input || "serve",
         params: {
           page: page,
           hitsPerPage: kind === "All" ? 5 : 10,
+          clickAnalytics: true,
           filters: Object.entries(symbolKindsToggle)
             .filter(([_, v]) => kind === "Symbols" ? v : true)
             .map(([k]) => "kind:" + symbolKinds[k as keyof typeof symbolKinds])
@@ -139,11 +177,12 @@ export default function GlobalSearch() {
 
     if (kind === "Modules" || kind === "All") {
       queries.push({
-        indexName: "modules",
+        indexName: MODULE_INDEX,
         query: input,
         params: {
           page: page,
           hitsPerPage: kind === "All" ? 5 : 10,
+          clickAnalytics: true,
         },
       });
     }
@@ -153,12 +192,9 @@ export default function GlobalSearch() {
         // @ts-ignore algolia typings are annoying
         setTotalPages(results.find((res) => res.nbPages)?.nbPages ?? 1);
         setResults({
-          // @ts-ignore algolia typings are annoying
-          manual: results.find((res) => res.index === "manual")?.hits,
-          // @ts-ignore algolia typings are annoying
-          symbols: results.find((res) => res.index === "doc_nodes")?.hits,
-          // @ts-ignore algolia typings are annoying
-          modules: results.find((res) => res.index === "modules")?.hits,
+          manual: toSearchResults(results, MANUAL_INDEX),
+          symbols: toSearchResults(results, SYMBOL_INDEX),
+          modules: toSearchResults(results, MODULE_INDEX),
         });
       },
     );
@@ -261,37 +297,56 @@ export default function GlobalSearch() {
                   <>
                     {results.manual && (
                       <Section title="Manual" isAll={kind === "All"}>
-                        {results.manual && results.manual.length === 0 && (
+                        {results.manual && results.manual.hits.length === 0 && (
                           <div class={tw`text-gray-500 italic`}>
                             Your search did not yield any results in the manual.
                           </div>
                         )}
-                        {results.manual.map((res) => <ManualResult {...res} />)}
+                        {results.manual.hits.map((res, i) => (
+                          <ManualResult
+                            {...res}
+                            userToken={userToken}
+                            queryID={results.manual!.queryID}
+                            position={getPosition(results.manual!, i)}
+                          />
+                        ))}
                       </Section>
                     )}
                     {results.modules && (
                       <Section title="Modules" isAll={kind === "All"}>
-                        {results.modules && results.modules.length === 0 && (
-                          <div class={tw`text-gray-500 italic`}>
-                            Your search did not yield any results in the modules
-                            index.
-                          </div>
-                        )}
-                        {results.modules.map((module) => (
-                          <ModuleResult module={module} />
+                        {results.modules && results.modules.hits.length === 0 &&
+                          (
+                            <div class={tw`text-gray-500 italic`}>
+                              Your search did not yield any results in the
+                              modules index.
+                            </div>
+                          )}
+                        {results.modules.hits.map((module, i) => (
+                          <ModuleResult
+                            module={module}
+                            userToken={userToken}
+                            queryID={results.modules!.queryID}
+                            position={getPosition(results.modules!, i)}
+                          />
                         ))}
                       </Section>
                     )}
                     {results.symbols && (
                       <Section title="Symbols" isAll={kind === "All"}>
-                        {results.symbols && results.symbols.length === 0 && (
-                          <div class={tw`text-gray-500 italic`}>
-                            Your search did not yield any results in the symbol
-                            index.
-                          </div>
-                        )}
-                        {results.symbols.map((doc) => (
-                          <SymbolResult doc={doc} />
+                        {results.symbols && results.symbols.hits.length === 0 &&
+                          (
+                            <div class={tw`text-gray-500 italic`}>
+                              Your search did not yield any results in the
+                              symbol index.
+                            </div>
+                          )}
+                        {results.symbols.hits.map((doc, i) => (
+                          <SymbolResult
+                            doc={doc}
+                            userToken={userToken}
+                            queryID={results.symbols!.queryID}
+                            position={getPosition(results.symbols!, i)}
+                          />
                         ))}
                       </Section>
                     )}
@@ -399,10 +454,29 @@ function Section({
   );
 }
 
-function ManualResult({ hierarchy, docPath, content }: ManualSearchResult) {
+function ManualResult(
+  { hierarchy, docPath, content, objectID, userToken, queryID, position }:
+    & ManualSearchResult
+    & {
+      objectID: string;
+      userToken?: string;
+      queryID?: string;
+      position?: number;
+    },
+) {
   const title = Object.values(hierarchy).filter(Boolean);
   return (
-    <a href={docPath}>
+    <a
+      href={docPath}
+      onClick={() =>
+        searchClick(
+          userToken,
+          MANUAL_INDEX,
+          queryID,
+          objectID,
+          position,
+        )}
+    >
       <div class={tw`p-1.5 rounded-full bg-gray-200`}>
         <Icons.Docs />
       </div>
@@ -432,13 +506,30 @@ function ManualResultTitle(props: { title: string[] }) {
   return <div class={tw`space-x-1`}>{parts}</div>;
 }
 
-function SymbolResult({ doc }: { doc: DocNode }) {
+function SymbolResult(
+  { doc, userToken, queryID, position }: {
+    doc: DocNode & { objectID: string };
+    userToken?: string;
+    queryID?: string;
+    position?: number;
+  },
+) {
   let location = new URL(doc.location.filename).pathname;
   location = location.replace(/^(\/x\/)|\//, "");
   const KindIcon = docNodeKindMap[doc.kind];
   const href = `${doc.location.filename}?s=${doc.name}`;
   return (
-    <a href={href}>
+    <a
+      href={href}
+      onClick={() =>
+        searchClick(
+          userToken,
+          SYMBOL_INDEX,
+          queryID,
+          doc.objectID,
+          position,
+        )}
+    >
       <KindIcon />
       <div>
         <div class={tw`space-x-2 py-1`}>
@@ -461,9 +552,26 @@ function SymbolResult({ doc }: { doc: DocNode }) {
   );
 }
 
-function ModuleResult({ module }: { module: ModuleSearchResult }) {
+function ModuleResult(
+  { module, userToken, queryID, position }: {
+    module: ModuleSearchResult & { objectID: string };
+    userToken?: string;
+    queryID?: string;
+    position?: number;
+  },
+) {
   return (
-    <a href={`https://deno.land/x/${module.name}`}>
+    <a
+      href={`https://deno.land/x/${module.name}`}
+      onClick={() =>
+        searchClick(
+          userToken,
+          MODULE_INDEX,
+          queryID,
+          module.objectID,
+          position,
+        )}
+    >
       <div class={tw`p-1.5 rounded-full bg-gray-200`}>
         <Icons.Module />
       </div>

--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -4,6 +4,7 @@
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
 import algoliasearch from "$algolia";
+import { createFetchRequester } from "$algolia/requester-fetch";
 import { IS_BROWSER } from "$fresh/runtime.ts";
 import { css, tw } from "@twind";
 import { useEffect, useState } from "preact/hooks";
@@ -76,9 +77,11 @@ export default function GlobalSearch() {
     "Type Aliases": true,
   });
 
+  const requester = createFetchRequester();
   const client = algoliasearch(
     "QFPCRZC6WX",
     "2ed789b2981acd210267b27f03ab47da",
+    { requester },
   );
 
   useEffect(() => {

--- a/routes/_404.tsx
+++ b/routes/_404.tsx
@@ -6,8 +6,14 @@ import { Head } from "$fresh/runtime.ts";
 import { tw } from "@twind";
 import { Header } from "@/components/Header.tsx";
 import { Footer } from "@/components/Footer.tsx";
+import { Handler, PageProps } from "$fresh/server.ts";
+import { type State } from "@/routes/_middleware.ts";
 
-export default function NotFoundPage() {
+interface Data {
+  userToken: string;
+}
+
+export default function NotFoundPage({ data: { userToken } }: PageProps<Data>) {
   return (
     <div
       class={tw`w-full min-h-screen overflow-x-hidden relative flex justify-between flex-col flex-wrap`}
@@ -16,7 +22,7 @@ export default function NotFoundPage() {
         <title>Not Found | Deno</title>
       </Head>
       <div class={tw`flex-top`}>
-        <Header />
+        <Header userToken={userToken} />
         <header class={tw`text-center px-8 py-[10vh] z-[3]`}>
           <h1
             class={tw`font-extrabold text-5xl leading-10 tracking-tight text-gray-900`}
@@ -50,3 +56,10 @@ export default function NotFoundPage() {
     </div>
   );
 }
+
+export const handler: Handler<Data, State> = (
+  _,
+  { render, state: { userToken } },
+) => {
+  return render!({ userToken });
+};

--- a/routes/_middleware.ts
+++ b/routes/_middleware.ts
@@ -1,0 +1,40 @@
+import { MiddlewareHandlerContext } from "$fresh/server.ts";
+
+function assert(cond: unknown, msg = "Assertion failed"): asserts cond {
+  if (!cond) {
+    throw new Error(msg);
+  }
+}
+
+export async function getUserToken(
+  headers: Headers,
+  hostname: string,
+): Promise<string> {
+  let ip: string;
+  const xForwardedFor = headers.get("x-forwarded-for");
+  if (xForwardedFor) {
+    ip = xForwardedFor.split(/\s*,\s*/)[0];
+  } else {
+    ip = hostname;
+  }
+  const data = new TextEncoder().encode(ip);
+  const buff = await crypto.subtle.digest("SHA-256", data);
+  const arr = Array.from(new Uint8Array(buff));
+  return arr.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export interface State {
+  userToken: string;
+}
+
+export async function handler(
+  req: Request,
+  ctx: MiddlewareHandlerContext<State>,
+) {
+  assert(ctx.remoteAddr.transport === "tcp");
+  ctx.state.userToken = await getUserToken(
+    req.headers,
+    ctx.remoteAddr.hostname,
+  );
+  return ctx.next();
+}

--- a/routes/add_module.tsx
+++ b/routes/add_module.tsx
@@ -9,15 +9,23 @@ import { Header } from "@/components/Header.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import AddModule from "@/islands/AddModule.tsx";
 import * as Icons from "@/components/Icons.tsx";
+import { Handlers, PageProps } from "$fresh/server.ts";
+import { type State } from "@/routes/_middleware.ts";
 
-export default function AddModulePage() {
+interface Data {
+  userToken: string;
+}
+
+export default function AddModulePage(
+  { data: { userToken } }: PageProps<Data>,
+) {
   return (
     <>
       <Head>
         <title>Third Party Modules | Deno</title>
       </Head>
       <div>
-        <Header selected="Third Party Modules" />
+        <Header selected="Third Party Modules" userToken={userToken} />
         <div
           class={tw`section-x-inset-xl mt-16 mb-28 flex items-center flex-col gap-12 lg:(items-start flex-row gap-36)`}
         >
@@ -55,3 +63,9 @@ export default function AddModulePage() {
     </>
   );
 }
+
+export const handler: Handlers<Data, State> = {
+  GET(_, { render, state: { userToken } }) {
+    return render!({ userToken });
+  },
+};

--- a/routes/artwork.tsx
+++ b/routes/artwork.tsx
@@ -8,6 +8,8 @@ import { tw } from "@twind";
 import { Footer } from "@/components/Footer.tsx";
 import { Header } from "@/components/Header.tsx";
 import * as Icons from "@/components/Icons.tsx";
+import { Handlers, PageProps } from "$fresh/server.ts";
+import { type State } from "@/routes/_middleware.ts";
 
 import artworks from "@/data/artwork.json" assert { type: "json" };
 
@@ -32,13 +34,17 @@ interface Artist {
   web?: string;
 }
 
-export default function ArtworkPage() {
+interface Data {
+  userToken: string;
+}
+
+export default function ArtworkPage({ data: { userToken } }: PageProps<Data>) {
   return (
     <>
       <Head>
         <title>Artwork | Deno</title>
       </Head>
-      <Header />
+      <Header userToken={userToken} />
       <div class={tw`section-x-inset-xl mt-8 mb-24`}>
         <div class={tw`max-w-screen-lg mx-auto`}>
           <h4 class={tw`text-4xl font-bold tracking-tight`}>Artwork</h4>
@@ -136,3 +142,9 @@ function Item({ artwork }: { artwork: Artwork }) {
     </div>
   );
 }
+
+export const handler: Handlers<Data, State> = {
+  GET(_, { render, state: { userToken } }) {
+    return render!({ userToken });
+  },
+};

--- a/routes/benchmarks.tsx
+++ b/routes/benchmarks.tsx
@@ -10,6 +10,7 @@ import { Handlers } from "$fresh/server.ts";
 import { Header } from "@/components/Header.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import { InlineCode } from "@/components/InlineCode.tsx";
+import { type State } from "@/routes/_middleware.ts";
 
 import {
   BenchmarkRun,
@@ -27,6 +28,7 @@ type ShowData = { dataFile: string; range: number[]; search: string };
 interface Data {
   show: ShowData;
   rawData: BenchmarkRun[];
+  userToken: string;
 }
 
 // TODO(lucacasonato): add anchor points to headers
@@ -159,7 +161,7 @@ export default function Benchmarks({ url, data }: PageProps<Data>) {
         }}
       />
       <div class={tw`bg-gray-50 min-h-full`}>
-        <Header />
+        <Header userToken={data.userToken} />
         <div class={tw`mb-12`}>
           <div
             class={tw`section-x-inset-md mt-8 pb-8`}
@@ -493,8 +495,8 @@ function SourceLink({
   );
 }
 
-export const handler: Handlers<Data> = {
-  async GET(req, { render }) {
+export const handler: Handlers<Data, State> = {
+  async GET(req, { render, state: { userToken } }) {
     const url = new URL(req.url);
     const showAll = url.searchParams.has("all");
     let show: ShowData = {
@@ -532,6 +534,6 @@ export const handler: Handlers<Data> = {
       `https://denoland.github.io/benchmark_data/${show.dataFile}`,
     );
 
-    return render!({ show, rawData: await res.json() });
+    return render!({ show, rawData: await res.json(), userToken });
   },
 };

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -12,10 +12,12 @@ import { Header } from "@/components/Header.tsx";
 import HelloBar from "@/islands/HelloBar.tsx";
 import { Background } from "@/components/HeroBackground.tsx";
 import { Handlers, PageProps } from "$fresh/server.ts";
+import { type State } from "@/routes/_middleware.ts";
 
 import versions from "@/versions.json" assert { type: "json" };
 
 interface Data {
+  userToken: string;
   isFirefox: boolean;
 }
 
@@ -50,7 +52,7 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (27ms
           class={tw`bg-gray-50 overflow-x-hidden border-b border-gray-200 relative`}
         >
           {!data.isFirefox && <Background />}
-          <Header main />
+          <Header main userToken={data.userToken} />
           <div
             class={tw`relative section-x-inset-sm pt-12 pb-20 flex flex-col items-center`}
           >
@@ -463,9 +465,10 @@ function InstallSection({ url }: { url: URL }) {
   );
 }
 
-export const handler: Handlers<Data> = {
-  GET(req, { render }) {
+export const handler: Handlers<Data, State> = {
+  GET(req, { render, state: { userToken } }) {
     return render!({
+      userToken,
       isFirefox:
         req.headers.get("user-agent")?.toLowerCase().includes("firefox") ??
           false,

--- a/routes/manual.tsx
+++ b/routes/manual.tsx
@@ -21,6 +21,7 @@ import {
   versions,
 } from "@/util/manual_utils.ts";
 import VersionSelect from "@/islands/VersionSelect.tsx";
+import { type State } from "@/routes/_middleware.ts";
 
 import VERSIONS from "@/versions.json" assert { type: "json" };
 
@@ -28,6 +29,7 @@ interface Data {
   tableOfContents: TableOfContents;
   content: string;
   version: string;
+  userToken: string;
 }
 
 export default function Manual({ params, url, data }: PageProps<Data>) {
@@ -83,7 +85,7 @@ export default function Manual({ params, url, data }: PageProps<Data>) {
         </title>
         <link rel="canonical" href={`https://deno.land/manual${path}`} />
       </Head>
-      <Header selected="Manual" manual />
+      <Header selected="Manual" manual userToken={data.userToken} />
 
       <SidePanelPage
         sidepanel={
@@ -269,8 +271,8 @@ function ToC({
   );
 }
 
-export const handler: Handlers<Data> = {
-  async GET(req, { params, render }) {
+export const handler: Handlers<Data, State> = {
+  async GET(req, { params, render, state: { userToken } }) {
     const url = new URL(req.url);
     const { version, path } = params;
     if (!version || !path) {
@@ -303,7 +305,7 @@ export const handler: Handlers<Data> = {
         }),
     ]);
 
-    return render!({ tableOfContents, content, version });
+    return render!({ tableOfContents, content, version, userToken });
   },
 };
 

--- a/routes/showcase.tsx
+++ b/routes/showcase.tsx
@@ -8,6 +8,8 @@ import { tw } from "@twind";
 import { Footer } from "@/components/Footer.tsx";
 import { Header } from "@/components/Header.tsx";
 import * as Icons from "@/components/Icons.tsx";
+import { Handlers, PageProps } from "$fresh/server.ts";
+import { type State } from "@/routes/_middleware.ts";
 
 import projects from "@/data/showcase.json" assert { type: "json" };
 
@@ -20,13 +22,17 @@ interface Project {
   github?: string;
 }
 
-export default function ShowcasePage() {
+interface Data {
+  userToken: string;
+}
+
+export default function ShowcasePage({ data: { userToken } }: PageProps<Data>) {
   return (
     <>
       <Head>
         <title>Showcase | Deno</title>
       </Head>
-      <Header />
+      <Header userToken={userToken} />
       <div class={tw`section-x-inset-xl mt-8 mb-24`}>
         <div class={tw`max-w-screen-lg mx-auto`}>
           <h4 class={tw`text-4xl font-bold tracking-tight`}>Showcase</h4>
@@ -82,3 +88,9 @@ function Item({ project }: { project: Project }) {
     </div>
   );
 }
+
+export const handler: Handlers<Data, State> = {
+  GET(_, { render, state: { userToken } }) {
+    return render!({ userToken });
+  },
+};

--- a/routes/status.tsx
+++ b/routes/status.tsx
@@ -11,15 +11,23 @@ import { Footer } from "@/components/Footer.tsx";
 import { Build, getBuild } from "@/util/registry_utils.ts";
 import { ErrorMessage } from "@/components/ErrorMessage.tsx";
 import * as Icons from "@/components/Icons.tsx";
+import { type State } from "@/routes/_middleware.ts";
 
-export default function StatusPage({ data }: PageProps<Build | Error>) {
+interface Data {
+  data: Build | Error;
+  userToken: string;
+}
+
+export default function StatusPage(
+  { data: { data, userToken } }: PageProps<Data>,
+) {
   return (
     <>
       <Head>
         <title>Publish Status | Deno</title>
       </Head>
       <div class={tw`bg-gray-50 min-h-full`}>
-        <Header />
+        <Header userToken={userToken} />
         <div class={tw`section-x-inset-md mt-8 pb-8 mb-16`}>
           <div>
             <h3 class={tw`text-lg leading-6 font-medium text-gray-900`}>
@@ -137,9 +145,9 @@ export default function StatusPage({ data }: PageProps<Build | Error>) {
   );
 }
 
-export const handler: Handlers<Build | Error> = {
-  async GET(req, { params, render }) {
-    return render!(await getBuild(params.id));
+export const handler: Handlers<Data, State> = {
+  async GET(_, { params, render, state: { userToken } }) {
+    return render!({ data: await getBuild(params.id), userToken });
   },
 };
 

--- a/routes/std.tsx
+++ b/routes/std.tsx
@@ -5,6 +5,7 @@ import { h } from "preact";
 import { PageProps, RouteConfig } from "$fresh/server.ts";
 import { Handlers } from "$fresh/server.ts";
 import Registry, { handler as xHandler } from "./x/module.tsx";
+import { type State } from "@/routes/_middleware.ts";
 
 export default function RegistryPage(props: PageProps) {
   props.params.name = "std";
@@ -14,7 +15,7 @@ export default function RegistryPage(props: PageProps) {
   return <Registry {...props} />;
 }
 
-export const handler: Handlers = {
+export const handler: Handlers<unknown, State> = {
   GET(req, ctx) {
     ctx.params.name = "std";
     if (ctx.params.version?.startsWith("v")) {

--- a/routes/translations.tsx
+++ b/routes/translations.tsx
@@ -8,6 +8,8 @@ import { tw } from "@twind";
 import { Footer } from "@/components/Footer.tsx";
 import { Header } from "@/components/Header.tsx";
 import * as Icons from "@/components/Icons.tsx";
+import { Handlers, PageProps } from "$fresh/server.ts";
+import { type State } from "@/routes/_middleware.ts";
 
 import translations from "@/data/translations.json" assert { type: "json" };
 
@@ -22,13 +24,19 @@ interface Translation {
   repository: string;
 }
 
-export default function TranslationsPage() {
+interface Data {
+  userToken: string;
+}
+
+export default function TranslationsPage(
+  { data: { userToken } }: PageProps<Data>,
+) {
   return (
     <>
       <Head>
         <title>Translations | Deno</title>
       </Head>
-      <Header />
+      <Header userToken={userToken} />
       <div class={tw`section-x-inset-xl mt-8 mb-24`}>
         <div class={tw`max-w-screen-lg mx-auto`}>
           <h4 class={tw`text-4xl font-bold tracking-tight`}>Translations</h4>
@@ -79,3 +87,9 @@ function LanguageItem({ language }: { language: Translation }) {
     </div>
   );
 }
+
+export const handler: Handlers<Data, State> = {
+  GET(_, { render, state: { userToken } }) {
+    return render!({ userToken });
+  },
+};

--- a/util/search_insights_utils.ts
+++ b/util/search_insights_utils.ts
@@ -1,0 +1,59 @@
+// Copyright 2022 the Deno authors. All rights reserved. MIT license.
+
+const INSIGHTS_ENDPOINT = "https://insights.algolia.io/1/events";
+const ALGOLIA_API_KEY = "2ed789b2981acd210267b27f03ab47da";
+const ALGOLIA_APPLICATION_ID = "QFPCRZC6WX";
+
+/**
+ * Report the search click event to algolia.
+ *
+ * @param userToken the current user token
+ * @param index the name of the index that was clicked
+ * @param queryID the query ID that resulted in the list
+ * @param objectID the object ID of the search result
+ * @param position the absolute position of search item in the results
+ */
+export async function searchClick(
+  userToken: string | undefined,
+  index: string,
+  queryID: string | undefined,
+  objectID: string,
+  position: number | undefined,
+): Promise<void> {
+  if (!userToken || !queryID || !position) {
+    return;
+  }
+  const event = {
+    eventType: "click",
+    eventName: `${index} search click`,
+    index,
+    userToken,
+    timestamp: Date.now(),
+    queryID,
+    objectIDs: [objectID],
+    positions: [position],
+  };
+  const body = JSON.stringify({ events: [event] });
+  try {
+    const res = await fetch(INSIGHTS_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "x-algolia-api-key": ALGOLIA_API_KEY,
+        "x-algolia-application-id": ALGOLIA_APPLICATION_ID,
+        "content-type": "application/json",
+      },
+      body,
+    });
+    if (res.status !== 200) {
+      console.error("failed to post search click:", res.status, res.statusText);
+    }
+  } catch (e) {
+    if (e instanceof TypeError) {
+      console.warn(
+        "Unable to report search events, most likely due to an ad blocker.",
+      );
+    } else {
+      console.error("An unexpected error occurred.", e);
+    }
+  }
+}


### PR DESCRIPTION
This add search event reporting when a user clicks on a search item in the global search box.

It generates a hashed version of the connection information presented to the server. This means there are no cookies dropped on a users machine, and the information is only used to attempt to uniquely identify users to algolia for its reporting and analytics.