### PR TITLE
chore: use cdn.deno.land again

### DIFF
--- a/util/manual_utils_test.ts
+++ b/util/manual_utils_test.ts
@@ -17,14 +17,14 @@ Deno.test("get introduction file commit hash", () => {
 Deno.test("get introduction file old repo", () => {
   assertEquals(
     getFileURL("v1.12.0", "/introduction"),
-    "https://cdn2.deno.land/deno/versions/v1.12.0/raw/docs/introduction.md",
+    "https://cdn.deno.land/deno/versions/v1.12.0/raw/docs/introduction.md",
   );
 });
 
 Deno.test("get introduction file new repo", () => {
   assertEquals(
     getFileURL("v1.12.1", "/introduction"),
-    "https://cdn2.deno.land/manual/versions/v1.12.1/raw/introduction.md",
+    "https://cdn.deno.land/manual/versions/v1.12.1/raw/introduction.md",
   );
 });
 

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -1,6 +1,6 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
-export const CDN_ENDPOINT = "https://cdn2.deno.land/";
+export const CDN_ENDPOINT = "https://cdn.deno.land/";
 const API_ENDPOINT = "https://api.deno.land/";
 
 export interface CommonProps<T> {

--- a/util/registry_utils_test.ts
+++ b/util/registry_utils_test.ts
@@ -11,7 +11,7 @@ import { assert, assertEquals } from "$std/testing/asserts.ts";
 Deno.test("source url", () => {
   assertEquals(
     getSourceURL("ltest2", "0.0.8", "/README.md"),
-    "https://cdn2.deno.land/ltest2/versions/0.0.8/raw/README.md",
+    "https://cdn.deno.land/ltest2/versions/0.0.8/raw/README.md",
   );
 });
 


### PR DESCRIPTION
cdn.deno.land is now hooked up to CloudFront.