### PR TITLE
fix: remove latest wording from modules

### DIFF
--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -196,7 +196,7 @@ async function handlerRaw(
         ...RAW_HEADERS,
         Location: getModulePath(name, versions.latest, path),
         "x-deno-warning":
-          `Implicitly using latest version (${versions.latest}) for ${req.url}`,
+          `Implicitly using version (${versions.latest}) for ${req.url}`,
       },
     });
   }

--- a/tests/handler_test.ts
+++ b/tests/handler_test.ts
@@ -91,7 +91,6 @@ Deno.test({
     );
     assertEquals(res.status, 302);
     assert(res.headers.get("Location")?.includes("@"));
-    assert(res.headers.get("X-Deno-Warning")?.includes("latest"));
     assert(res.headers.get("X-Deno-Warning")?.includes("/std/version.ts"));
     assertEquals(res.headers.get("Access-Control-Allow-Origin"), "*");
     await res.text();


### PR DESCRIPTION
`Latest` is not accurate especially with deno that tends to cache responses, this can lead to misleading warnings see https://github.com/denoland/deno/issues/14933