### PR TITLE
feat: update global search to use new symbol index

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,6 +6,7 @@ import { h } from "preact";
 import { apply, css, tw } from "@twind";
 import * as Icons from "./Icons.tsx";
 import GlobalSearch from "@/islands/GlobalSearch.tsx";
+import versions from "@/versions.json" assert { type: "json" };
 
 const entries = [
   { href: "/manual", content: "Manual" },
@@ -56,7 +57,7 @@ export function Header({ selected, main, manual }: {
               <img class={tw`h-full w-full`} src="/logo.svg" alt="Deno Logo" />
             </a>
 
-            <GlobalSearch />
+            <GlobalSearch denoVersion={versions.cli[0]} />
 
             <label
               tabIndex={0}

--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -559,7 +559,6 @@ function Source(
 }
 
 const tagColors = {
-  purple: ["[#7B61FF1A]", "[#7B61FF]"],
   cyan: ["[#0CAFC619]", "[#0CAFC6]"],
   gray: ["gray-100", "gray-400"],
 } as const;

--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -2,7 +2,7 @@
 
 /** @jsx h */
 /** @jsxFrag Fragment */
-import { Fragment, h } from "preact";
+import { type ComponentChildren, Fragment, h } from "preact";
 import algoliasearch from "$algolia";
 import type {
   MultipleQueriesQuery,
@@ -15,7 +15,6 @@ import { useEffect, useState } from "preact/hooks";
 import * as Icons from "@/components/Icons.tsx";
 import { colors, docNodeKindMap } from "@/components/symbol_kind.tsx";
 import { islandSearchClick } from "@/util/search_insights_utils.ts";
-import { ComponentChildren } from "preact";
 
 // Lazy load a <dialog> polyfill.
 // @ts-expect-error HTMLDialogElement is not just a type!
@@ -559,6 +558,27 @@ function Source(
   }
 }
 
+const tagColors = {
+  purple: ["[#7B61FF1A]", "[#7B61FF]"],
+  cyan: ["[#0CAFC619]", "[#0CAFC6]"],
+  gray: ["gray-100", "gray-400"],
+} as const;
+
+type TagColors = keyof typeof tagColors;
+
+function Tag(
+  { children, color }: { children: ComponentChildren; color: TagColors },
+) {
+  const [bg, text] = tagColors[color];
+  return (
+    <div
+      class={tw`bg-${bg} text-${text} py-1 px-2 inline-block rounded-full font-medium text-sm leading-none mr-2 font-sans`}
+    >
+      {children}
+    </div>
+  );
+}
+
 function SymbolDescription(
   { children: { doc, tags } }: { children: SymbolItem },
 ) {
@@ -566,7 +586,7 @@ function SymbolDescription(
     return null;
   }
   const tagItems = tags?.map((tag) => (
-    <span class={tw`p-1 rounded-xl border-2 mr-2`}>{tag}</span>
+    <Tag color={tag.startsWith("allow") ? "cyan" : "gray"}>{tag}</Tag>
   ));
   return (
     <div

--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -583,27 +583,6 @@ function Tag(
   );
 }
 
-function SymbolDescription(
-  { children: { doc, tags } }: { children: SymbolItem },
-) {
-  if (!doc && !tags) {
-    return null;
-  }
-  const tagItems = tags?.map((tag) => (
-    <Tag color={tag.startsWith("allow") ? "cyan" : "gray"}>{tag}</Tag>
-  ));
-  return (
-    <div
-      class={tw`text-sm text-[#6C6E78] mr-24`}
-    >
-      {tagItems && tagItems.length
-        ? <div class={tw`mb-2`}>{tagItems}</div>
-        : null}
-      {doc?.split("\n\n")[0]}
-    </div>
-  );
-}
-
 function SymbolResult(
   { children: item, queryID, position, denoVersion }: {
     children: SymbolItem & { objectID: string };
@@ -614,6 +593,10 @@ function SymbolResult(
 ) {
   const KindIcon = docNodeKindMap[item.kind];
   const href = getSymbolItemHref(item, denoVersion);
+  const tagItems = item.tags?.map((tag) => (
+    <Tag color={tag.startsWith("allow") ? "cyan" : "gray"}>{tag}</Tag>
+  ));
+
   return (
     <a
       href={href}
@@ -621,15 +604,25 @@ function SymbolResult(
         islandSearchClick(SYMBOL_INDEX, queryID, item.objectID, position)}
     >
       <KindIcon />
-      <div>
-        <div class={tw`space-x-2 py-1`}>
-          <span class={tw`text-[${colors[item.kind][0]}]`}>
-            {item.kind.replace("A", " a")}
-          </span>
-          <span class={tw`font-semibold`}>{item.name}</span>
-          <Source>{item}</Source>
+      <div class={tw`w-full`}>
+        <div
+          class={tw`flex flex-col py-1 md:(flex-row items-center justify-between gap-2 mb-0)`}
+        >
+          <div class={tw`space-x-2`}>
+            <span class={tw`text-[${colors[item.kind][0]}]`}>
+              {item.kind.replace("A", " a")}
+            </span>
+            <span class={tw`font-semibold`}>{item.name}</span>
+            <Source>{item}</Source>
+          </div>
+          {tagItems && tagItems.length && <div class={tw`mr-3`}>{tagItems}
+          </div>}
         </div>
-        <SymbolDescription>{item}</SymbolDescription>
+        {item.doc && (
+          <div class={tw`text-sm text-[#6C6E78]`}>
+            {item.doc.split("\n\n")[0]}
+          </div>
+        )}
       </div>
     </a>
   );

--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -215,7 +215,6 @@ export default function GlobalSearch() {
 
     client.multipleQueries(queries).then(
       ({ results }) => {
-        // @ts-ignore algolia typings are annoying
         setTotalPages(results.find((res) => res.nbPages)?.nbPages ?? 1);
         setResults({
           manual: toSearchResults(results, MANUAL_INDEX),

--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -523,10 +523,12 @@ function ManualResultTitle(props: { title: string[] }) {
 
 /** Given a symbol item, return an href that will link to that symbol. */
 function getSymbolItemHref(
-  { sourceId, name, version, path }: SymbolItem,
+  { sourceId, name, version, path, tags }: SymbolItem,
 ): string {
   if (sourceId.startsWith("lib/")) {
-    return `/api?s=${name}`;
+    return tags && tags.includes("unstable")
+      ? `/api?unstable=&s=${name}`
+      : `/api?s=${name}`;
   } else if (sourceId === "mod/std") {
     return `/std@${version}${path}${name ? `?s=${name}` : ""}`;
   } else {

--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -606,7 +606,7 @@ function SymbolResult(
       <KindIcon />
       <div class={tw`w-full`}>
         <div
-          class={tw`flex flex-col py-1 md:(flex-row items-center justify-between gap-2 mb-0)`}
+          class={tw`flex flex-col py-1 md:(flex-row items-center justify-between gap-2)`}
         >
           <div class={tw`space-x-2`}>
             <span class={tw`text-[${colors[item.kind][0]}]`}>


### PR DESCRIPTION
We need to land #2428 as well as populate building out the new symbol index in search.

@crowlKats I am sure the tags need some work, but wanted to demonstrate how they go in...  Category is in the search payload too, but I am not displaying that yet.