### PR TITLE
Remove object graph meta properties

### DIFF
--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -13,32 +13,8 @@ export default function App({ Component }: AppProps) {
       <Head>
         <link rel="icon" href="/favicon.ico" sizes="32x32" />
         <link rel="icon" href="/logo.svg" type="image/svg+xml" />
-
         <meta name="twitter:site" content="@deno_land" />
         <meta name="twitter:creator" content="@deno_land" />
-        <meta
-          name="twitter:title"
-          content="Deno - A modern runtime for JavaScript and TypeScript"
-        />
-        <meta
-          name="twitter:description"
-          content="Deno is a simple, modern runtime for JavaScript and
-            TypeScript that uses V8 and is built in Rust."
-        />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta property="og:locale" content="en_US" />
-        <meta property="og:site_name" content="DenoLand" />
-        <meta
-          property="og:title"
-          content="Deno - A modern runtime for JavaScript and TypeScript"
-        />
-        <meta
-          property="og:description"
-          content="Deno is a simple, modern runtime for JavaScript and
-            TypeScript that uses V8 and is built in Rust."
-        />
-        <meta property="og:image" content="https://deno.land/og-image.png" />
-        <meta property="og:type" content="website" />
         <meta name="robots" content="index, follow" />
         <meta
           name="keywords"


### PR DESCRIPTION
The object graph cards for deno.land are not helpful - every page shows the same thing. Until we can dynamically create better cards for each page, I think it should be removed.