### PR TITLE
add cursor-pointer to menu and cross icon in header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -63,7 +63,7 @@ export function Header({ selected, main, manual }: {
 
             <label
               tabIndex={0}
-              class={tw`lg:hidden ${
+              class={tw`cursor-pointer lg:hidden ${
                 css({
                   "touch-action": "manipulation",
                 })


### PR DESCRIPTION
I noticed that there is no pointer cursor in the mobile header element when hovering over the menu icon.