### PR TITLE
remove scroll into view on manual

### DIFF
--- a/routes/manual.tsx
+++ b/routes/manual.tsx
@@ -161,18 +161,7 @@ export default function Manual({ params, url, data }: PageProps<Data>) {
           </div>
         </div>
       </SidePanelPage>
-
       <Footer />
-
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `
-        (function() {
-          document.querySelectorAll(".toc-active").forEach(el=>{el.scrollIntoView({block:"center"});});
-        })();
-      `,
-        }}
-      />
     </>
   );
 }

--- a/routes/manual.tsx
+++ b/routes/manual.tsx
@@ -226,8 +226,7 @@ function ToCEntry({
           outermost
             ? "px-2.5 py-2 font-semibold"
             : `pl-${depth * 6} pr-2.5 py-1 font-normal`
-        } rounded-md ${active ? "link bg-ultralight" : "hover:text-gray-500"}` +
-          (active ? " toc-active" : "")}
+        } rounded-md ${active ? "link bg-ultralight" : "hover:text-gray-500"}`}
       >
         <Icons.TriangleRight
           aria-label={`open section ${name}`}


### PR DESCRIPTION
Since the redesign of the manual allowed us to collapse the navigation, we no longer need the scroll into view function of the links that I implemented back then.

Fixes #2485