### PR TITLE
feat: enrich page metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
           deno-version: v1.x
 
       - name: Run Tests
-        run: deno test --allow-net --allow-read --allow-env --allow-hrtime
+        run: deno task test

--- a/components/ContentMeta.tsx
+++ b/components/ContentMeta.tsx
@@ -1,0 +1,71 @@
+// Copyright 2022 the Deno authors. All rights reserved. MIT license.
+
+/** @jsx h */
+/** @jsxFrag Fragment */
+import { Fragment, h } from "preact";
+import { Head } from "$fresh/runtime.ts";
+
+const DEFAULT_TITLE = "Deno";
+const DEFAULT_KEYWORDS = [
+  "deno",
+  "denoland",
+  "development",
+  "javascript",
+  "typescript",
+  "wasm",
+];
+
+type OgType = "website" | "article";
+
+/** A component which provides a unified way of setting the header meta data
+ * in a structured way. */
+export function ContentMeta(
+  {
+    title = DEFAULT_TITLE,
+    description,
+    creator,
+    keywords = DEFAULT_KEYWORDS,
+    ogType = "website",
+    noIndex = false,
+    noAppendTitle = false,
+  }: {
+    title: string;
+    description?: string;
+    creator?: string;
+    keywords?: string[];
+    ogType?: OgType;
+    noIndex?: boolean;
+    noAppendTitle?: boolean;
+  },
+) {
+  if (!title.endsWith("| Deno") && !noAppendTitle) {
+    title = `${title} | Deno`;
+  }
+  return (
+    <Head>
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:site:id" content="@deno_land" />
+
+      <title>{title}</title>
+      <meta name="twitter:title" content={title} />
+      <meta property="og:title" content={title} />
+
+      {creator && <meta name="twitter:creator:id" content={creator} />}
+
+      <meta property="og:type" content={ogType} />
+      <meta property="og:site_name" content="Deno" />
+      <meta property="og:locale" content="en_US" />
+
+      <meta name="robots" content={noIndex ? "noindex" : "index, follow"} />
+      <meta name="keywords" content={keywords.join(", ")} />
+
+      {description && (
+        <>
+          <meta name="twitter:description" content={description} />
+          <meta property="og:description" content={description} />
+          <meta name="description" content={description} />
+        </>
+      )}
+    </Head>
+  );
+}

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "tasks": {
-    "start": "deno run -A --watch=routes/,static/ dev.ts"
+    "start": "deno run -A --watch=routes/,static/ dev.ts",
+    "test": "deno test --allow-net --allow-read --allow-env --allow-hrtime"
   },
   "compilerOptions": {
     "types": [

--- a/routes/_404.tsx
+++ b/routes/_404.tsx
@@ -2,8 +2,8 @@
 
 /** @jsx h */
 import { h } from "preact";
-import { Head } from "$fresh/runtime.ts";
 import { tw } from "@twind";
+import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Header } from "@/components/Header.tsx";
 import { Footer } from "@/components/Footer.tsx";
 
@@ -12,9 +12,7 @@ export default function NotFoundPage() {
     <div
       class={tw`w-full min-h-screen overflow-x-hidden relative flex justify-between flex-col flex-wrap`}
     >
-      <Head>
-        <title>Not Found | Deno</title>
-      </Head>
+      <ContentMeta title="Not Found" />
       <div class={tw`flex-top`}>
         <Header />
         <header class={tw`text-center px-8 py-[10vh] z-[3]`}>

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -13,13 +13,6 @@ export default function App({ Component }: AppProps) {
       <Head>
         <link rel="icon" href="/favicon.ico" sizes="32x32" />
         <link rel="icon" href="/logo.svg" type="image/svg+xml" />
-        <meta name="twitter:site" content="@deno_land" />
-        <meta name="twitter:creator" content="@deno_land" />
-        <meta name="robots" content="index, follow" />
-        <meta
-          name="keywords"
-          content="Deno, DenoLand, Development, JavaScript, TypeScript"
-        />
         <link rel="stylesheet" href="/fonts/inter/inter.css" />
         <link rel="manifest" href="/site.webmanifest" />
 

--- a/routes/add_module.tsx
+++ b/routes/add_module.tsx
@@ -3,8 +3,8 @@
 /** @jsx h */
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
-import { Head } from "$fresh/runtime.ts";
 import { tw } from "@twind";
+import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Header } from "@/components/Header.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import AddModule from "@/islands/AddModule.tsx";
@@ -13,9 +13,12 @@ import * as Icons from "@/components/Icons.tsx";
 export default function AddModulePage() {
   return (
     <>
-      <Head>
-        <title>Third Party Modules | Deno</title>
-      </Head>
+      <ContentMeta
+        title="Third Party Modules"
+        description="Register a module with deno.land/x."
+        creator="@deno_land"
+        keywords={["deno", "registry", "modules", "javascript", "typescript"]}
+      />
       <div>
         <Header selected="Third Party Modules" />
         <div

--- a/routes/add_module.tsx
+++ b/routes/add_module.tsx
@@ -15,7 +15,8 @@ export default function AddModulePage() {
     <>
       <ContentMeta
         title="Third Party Modules"
-        description="Register a module with deno.land/x."
+        description="Register a module with the third party
+          registry."
         creator="@deno_land"
         keywords={["deno", "registry", "modules", "javascript", "typescript"]}
       />

--- a/routes/api.tsx
+++ b/routes/api.tsx
@@ -4,15 +4,18 @@
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
 import { PageProps, RouteConfig } from "$fresh/server.ts";
-import { Head } from "$fresh/runtime.ts";
 import { tw } from "@twind";
 import { Handlers } from "$fresh/server.ts";
+import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Header } from "@/components/Header.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import { ManualOrAPI, SidePanelPage } from "@/components/SidePanelPage.tsx";
 import { versions } from "@/util/manual_utils.ts";
 import VersionSelect from "@/islands/VersionSelect.tsx";
-import { type LibDocPage } from "@/util/registry_utils.ts";
+import {
+  getLibDocPageDescription,
+  type LibDocPage,
+} from "@/util/registry_utils.ts";
 import { ErrorMessage } from "@/components/ErrorMessage.tsx";
 import { LibraryDocPanel } from "$doc_components/doc/library_doc_panel.tsx";
 import { LibraryDoc } from "$doc_components/doc/library_doc.tsx";
@@ -28,9 +31,14 @@ export default function API(
 
   return (
     <>
-      <Head>
-        <title>API | Deno</title>
-      </Head>
+      <ContentMeta
+        title={data.kind === "librarySymbol"
+          ? `${data.name} | Runtime APIs`
+          : "Runtime APIs"}
+        description={getLibDocPageDescription(data)}
+        creator="@deno_land"
+        keywords={["deno", "api", "built-in", "typescript", "javascript"]}
+      />
       <Header selected="API" manual />
 
       {data.kind === "libraryInvalidVersion"

--- a/routes/artwork.tsx
+++ b/routes/artwork.tsx
@@ -3,12 +3,11 @@
 /** @jsx h */
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
-import { Head } from "$fresh/runtime.ts";
 import { tw } from "@twind";
+import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import { Header } from "@/components/Header.tsx";
 import * as Icons from "@/components/Icons.tsx";
-import { Handlers, PageProps } from "$fresh/server.ts";
 
 import artworks from "@/data/artwork.json" assert { type: "json" };
 
@@ -36,9 +35,11 @@ interface Artist {
 export default function ArtworkPage() {
   return (
     <>
-      <Head>
-        <title>Artwork | Deno</title>
-      </Head>
+      <ContentMeta
+        title="Artwork"
+        description="Community created Deno artwork and logos."
+        keywords={["deno", "community", "artwork", "logo"]}
+      />
       <Header />
       <div class={tw`section-x-inset-xl mt-8 mb-24`}>
         <div class={tw`max-w-screen-lg mx-auto`}>

--- a/routes/benchmarks.tsx
+++ b/routes/benchmarks.tsx
@@ -4,8 +4,8 @@
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
 import { PageProps } from "$fresh/server.ts";
-import { Head } from "$fresh/runtime.ts";
 import { tw } from "@twind";
+import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Handlers } from "$fresh/server.ts";
 import { Header } from "@/components/Header.tsx";
 import { Footer } from "@/components/Footer.tsx";
@@ -138,11 +138,21 @@ export default function Benchmarks({ url, data }: PageProps<Data>) {
 
   return (
     <>
-      <Head>
-        <title>
-          Benchmarks {dataRangeTitle ? `(${dataRangeTitle}) ` : " "}| Deno
-        </title>
-      </Head>
+      <ContentMeta
+        title={`Benchmarks${dataRangeTitle ? ` (${dataRangeTitle})` : ""}`}
+        creator="@deno_land"
+        description="As part of Deno's continuous integration and testing
+          pipeline we measure the performance of certain key metrics of the 
+          runtime. You can view these benchmarks here."
+        keywords={[
+          "deno",
+          "benchmark",
+          "performance",
+          "v8",
+          "javascript",
+          "typescript",
+        ]}
+      />
       <script src="https://cdn.jsdelivr.net/npm/apexcharts" />
       <script
         id="data"

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -3,9 +3,9 @@
 /** @jsx h */
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
-import { Head } from "$fresh/runtime.ts";
 import { tw } from "@twind";
 import { CodeBlock } from "@/components/CodeBlock.tsx";
+import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import { InlineCode } from "@/components/InlineCode.tsx";
 import { Header } from "@/components/Header.tsx";
@@ -43,15 +43,19 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (27ms
     "https://deno.news/archive/50-the-javascript-trademark-fresh-11-and-deno-on";
   return (
     <div>
+      <ContentMeta
+        title="Deno — A modern runtime for JavaScript and TypeScript"
+        description="Deno is a simple, modern runtime for JavaScript and
+          TypeScript that uses V8 and is built in Rust."
+        creator="@deno_land"
+        noAppendTitle
+      />
       {hellobarTo !== data.hellobarClosedTo &&
         (
           <HelloBar to={hellobarTo}>
             Check out Deno News issue #50!
           </HelloBar>
         )}
-      <Head>
-        <title>Deno - A modern runtime for JavaScript and TypeScript</title>
-      </Head>
       <div class={tw`bg-white`}>
         <div
           class={tw`bg-gray-50 overflow-x-hidden border-b border-gray-200 relative`}

--- a/routes/manual.tsx
+++ b/routes/manual.tsx
@@ -4,15 +4,16 @@
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
 import { PageProps, RouteConfig } from "$fresh/server.ts";
-import { Head } from "$fresh/runtime.ts";
 import { tw } from "@twind";
 import { Handlers } from "$fresh/server.ts";
+import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Header } from "@/components/Header.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import { Markdown } from "@/components/Markdown.tsx";
 import * as Icons from "@/components/Icons.tsx";
 import { ManualOrAPI, SidePanelPage } from "@/components/SidePanelPage.tsx";
 import {
+  getDescription,
   getDocURL,
   getFileURL,
   getTableOfContents,
@@ -83,12 +84,19 @@ export default function Manual({ params, url, data }: PageProps<Data>) {
 
   return (
     <>
-      <Head>
-        <title>
-          {pageTitle === "" ? "Manual | Deno" : `${pageTitle} | Manual | Deno`}
-        </title>
-        <link rel="canonical" href={`https://deno.land/manual${path}`} />
-      </Head>
+      <ContentMeta
+        title={pageTitle ? `${pageTitle} | Manual` : "Manual"}
+        description={getDescription(data.content)}
+        creator="@deno_land"
+        ogType="article"
+        keywords={[
+          "deno",
+          "manual",
+          "documentation",
+          "javascript",
+          "typescript",
+        ]}
+      />
       <Header selected="Manual" manual />
 
       <SidePanelPage

--- a/routes/showcase.tsx
+++ b/routes/showcase.tsx
@@ -3,8 +3,8 @@
 /** @jsx h */
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
-import { Head } from "$fresh/runtime.ts";
 import { tw } from "@twind";
+import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import { Header } from "@/components/Header.tsx";
 import * as Icons from "@/components/Icons.tsx";
@@ -27,9 +27,11 @@ interface Data {
 export default function ShowcasePage() {
   return (
     <>
-      <Head>
-        <title>Showcase | Deno</title>
-      </Head>
+      <ContentMeta
+        title="Showcase"
+        description="Check out some websites, apps, and other products built with Deno."
+        keywords={["deno", "showcase", "javascript", "typescript"]}
+      />
       <Header />
       <div class={tw`section-x-inset-xl mt-8 mb-24`}>
         <div class={tw`max-w-screen-lg mx-auto`}>

--- a/routes/status.tsx
+++ b/routes/status.tsx
@@ -3,9 +3,9 @@
 /** @jsx h */
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
-import { Head } from "$fresh/runtime.ts";
 import { Handlers, PageProps, RouteConfig } from "$fresh/server.ts";
 import { tw } from "@twind";
+import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Header } from "@/components/Header.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import { Build, getBuild } from "@/util/registry_utils.ts";
@@ -21,9 +21,13 @@ export default function StatusPage(
 ) {
   return (
     <>
-      <Head>
-        <title>Publish Status | Deno</title>
-      </Head>
+      <ContentMeta
+        title="Publish Status"
+        description="The status of the publish webhook for the third party
+          registry."
+        creator="@deno_land"
+        keywords={["deno", "module", "registry", "status"]}
+      />
       <div class={tw`bg-gray-50 min-h-full`}>
         <Header />
         <div class={tw`section-x-inset-md mt-8 pb-8 mb-16`}>

--- a/routes/translations.tsx
+++ b/routes/translations.tsx
@@ -3,8 +3,8 @@
 /** @jsx h */
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
-import { Head } from "$fresh/runtime.ts";
 import { tw } from "@twind";
+import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import { Header } from "@/components/Header.tsx";
 import * as Icons from "@/components/Icons.tsx";
@@ -25,9 +25,11 @@ interface Translation {
 export default function TranslationsPage() {
   return (
     <>
-      <Head>
-        <title>Translations | Deno</title>
-      </Head>
+      <ContentMeta
+        title="Translations"
+        description="Deno docs is available in the following languages."
+        keywords={["deno", "documentation", "translation"]}
+      />
       <Header />
       <div class={tw`section-x-inset-xl mt-8 mb-24`}>
         <div class={tw`max-w-screen-lg mx-auto`}>

--- a/routes/x/index.tsx
+++ b/routes/x/index.tsx
@@ -4,7 +4,6 @@
 /** @jsxFrag Fragment */
 import { ComponentProps, Fragment, h } from "preact";
 import { PageProps } from "$fresh/server.ts";
-import { Head } from "$fresh/runtime.ts";
 import { css, tw } from "@twind";
 import { Handlers } from "$fresh/server.ts";
 import { emojify } from "$emoji";
@@ -13,6 +12,7 @@ import { createFetchRequester } from "$algolia/requester-fetch";
 
 import { PopularityModuleTag } from "@/util/registry_utils.ts";
 
+import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Header } from "@/components/Header.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import { InlineCode } from "@/components/InlineCode.tsx";
@@ -108,9 +108,12 @@ function ModuleHit(
 export default function ThirdPartyRegistryList({ data }: PageProps<Data>) {
   return (
     <>
-      <Head>
-        <title>Third Party Modules | Deno</title>
-      </Head>
+      <ContentMeta
+        title="Third Party Modules"
+        description="A hosting service for Deno scripts."
+        creator="@deno_land"
+        keywords={["deno", "third party", "module", "registry"]}
+      />
       <div>
         <Header selected="Third Party Modules" />
 

--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -4,7 +4,6 @@
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
 import { Handlers, PageProps, RouteConfig } from "$fresh/server.ts";
-import { Head } from "$fresh/runtime.ts";
 import { tw } from "@twind";
 import twas from "$twas";
 import { emojify } from "$emoji";
@@ -16,6 +15,7 @@ import {
   type DocPageSymbol,
   extractAltLineNumberReference,
   fetchSource,
+  getDocAsDescription,
   getModulePath,
   getRawFile,
   getReadme,
@@ -26,6 +26,7 @@ import {
   type ModInfoPage,
   type SourcePage,
 } from "@/util/registry_utils.ts";
+import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Header } from "@/components/Header.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import { ErrorMessage } from "@/components/ErrorMessage.tsx";
@@ -59,6 +60,57 @@ type MaybeData =
 
 interface PageData {
   data: MaybeData;
+}
+
+function getTitle(
+  module: string,
+  version: string | undefined,
+  data: MaybeData,
+): string {
+  if (!data) {
+    return "Third Party";
+  }
+  const title = [version ? `${module}@${version}` : module];
+  if (
+    data.view === "source" &&
+    (data.data.kind === "dir" || data.data.kind === "file")
+  ) {
+    title.unshift(data.data.path);
+  }
+  if (
+    data.view === "doc" &&
+    (data.data.kind === "module" || data.data.kind === "file" ||
+      data.data.kind === "index" || data.data.kind === "symbol")
+  ) {
+    title.unshift(data.data.path);
+    if (data.data.kind === "symbol") {
+      title.unshift(data.data.name);
+    }
+  }
+  return title.join(" | ");
+}
+
+function getDescription(data: MaybeData): string | undefined {
+  if (data) {
+    if (
+      (data.view === "info" && data.data.kind === "modinfo") ||
+      (data.view === "source" &&
+        (data.data.kind === "dir" || data.data.kind === "file")) ||
+      (data.view === "doc" &&
+        (data.data.kind === "index" || data.data.kind === "file"))
+    ) {
+      if (data.data.description) {
+        return emojify(data.data.description);
+      }
+    } else if (data.view === "doc") {
+      if (data.data.kind === "module") {
+        return getDocAsDescription(data.data.docNodes, true);
+      }
+      if (data.data.kind === "symbol") {
+        return getDocAsDescription(data.data.docNodes);
+      }
+    }
+  }
 }
 
 export const handler: Handlers<PageData> = {
@@ -233,9 +285,11 @@ export default function Registry(
 
   return (
     <>
-      <Head>
-        <title>{name + (version ? `@${version}` : "") + " | Deno"}</title>
-      </Head>
+      <ContentMeta
+        title={getTitle(name, version, data)}
+        description={getDescription(data)}
+        keywords={["deno", "third party", "module", name]}
+      />
       <div class={tw`bg-primary min-h-full`}>
         <Header
           selected={name === "std" ? "Standard Library" : "Third Party Modules"}

--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -123,15 +123,12 @@ export const handler: Handlers<PageData> = {
       return Response.redirect(url, 301);
     }
 
-    console.log("accept:", req.headers.get("accept"));
-    console.log("ua:", req.headers.get("user-agent"));
     // Deno CLI and bots both present with an `Accept: */*` header, where as
     // browsers will prefer HTML. Because of this, we have to try to infer a bot
     // from the UA in order to serve the HTML page.
     const isHTML = accepts(req, "application/*", "text/html") === "text/html" ||
       (req.headers.get("accept") === "*/*" &&
         req.headers.get("user-agent")?.includes("bot"));
-    console.log("isHTML", isHTML);
     if (!isHTML) return handlerRaw(req, params as Params);
 
     let view: Views;

--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -123,7 +123,10 @@ export const handler: Handlers<PageData> = {
       return Response.redirect(url, 301);
     }
 
+    console.log("accept:", req.headers.get("accept"));
+    console.log("ua:", req.headers.get("user-agent"));
     const isHTML = accepts(req, "application/*", "text/html") === "text/html";
+    console.log("isHTML", isHTML);
     if (!isHTML) return handlerRaw(req, params as Params);
 
     let view: Views;

--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -125,7 +125,12 @@ export const handler: Handlers<PageData> = {
 
     console.log("accept:", req.headers.get("accept"));
     console.log("ua:", req.headers.get("user-agent"));
-    const isHTML = accepts(req, "application/*", "text/html") === "text/html";
+    // Deno CLI and bots both present with an `Accept: */*` header, where as
+    // browsers will prefer HTML. Because of this, we have to try to infer a bot
+    // from the UA in order to serve the HTML page.
+    const isHTML = accepts(req, "application/*", "text/html") === "text/html" ||
+      (req.headers.get("accept") === "*/*" &&
+        req.headers.get("user-agent")?.includes("bot"));
     console.log("isHTML", isHTML);
     if (!isHTML) return handlerRaw(req, params as Params);
 

--- a/tests/handler_test.ts
+++ b/tests/handler_test.ts
@@ -65,7 +65,7 @@ Deno.test({
     const text = await res.text();
     assertStringIncludes(
       text,
-      "<title>Deno - A modern runtime for JavaScript and TypeScript</title>",
+      "<title>Deno — A modern runtime for JavaScript and TypeScript</title>",
     );
   },
 });

--- a/tests/handler_test.ts
+++ b/tests/handler_test.ts
@@ -81,7 +81,10 @@ Deno.test({
     );
     assert(res.headers.get("Content-Type")?.includes("text/html"));
     const text = await res.text();
-    assertStringIncludes(text, "<title>std@0.127.0 | Deno</title>");
+    assertStringIncludes(
+      text,
+      "<title>/version.ts | std@0.127.0 | Deno</title>",
+    );
   },
 });
 

--- a/util/manual_utils.ts
+++ b/util/manual_utils.ts
@@ -64,6 +64,15 @@ export function getDocURL(version: string, path: string): string {
   return `${sourcepath}${version}${path}.md`;
 }
 
+export function getDescription(content: string): string | undefined {
+  const paras = content.split("\n\n");
+  for (const para of paras) {
+    if (para.match(/^[^#`]/)) {
+      return para.slice(0, 199);
+    }
+  }
+}
+
 export function isPreviewVersion(version: string): boolean {
   return VERSIONS.cli.find((v) => v === version) === undefined;
 }

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -383,6 +383,41 @@ export function extractLinkUrl(
   return undefined;
 }
 
+function docAsDescription(doc: string) {
+  return doc.split("\n\n")[0].slice(0, 199);
+}
+
+/** For a LibDocPage, attempt to extract a description to be used with the
+ * content meta for the page. */
+export function getLibDocPageDescription(data: LibDocPage): string | undefined {
+  if (data.kind === "librarySymbol") {
+    for (const docNode of data.docNodes) {
+      if (docNode.jsDoc?.doc) {
+        return docAsDescription(docNode.jsDoc.doc);
+      }
+    }
+  }
+}
+
+export function getDocAsDescription(
+  docNodes: DocNode[],
+  modDoc = false,
+): string | undefined {
+  for (const docNode of docNodes) {
+    if (modDoc) {
+      if (docNode.kind === "moduleDoc") {
+        if (docNode.jsDoc.doc) {
+          return docAsDescription(docNode.jsDoc.doc);
+        } else {
+          return;
+        }
+      }
+    } else if (docNode.jsDoc?.doc) {
+      return docAsDescription(docNode.jsDoc.doc);
+    }
+  }
+}
+
 import type { DocNode, DocNodeKind, JsDoc } from "$deno_doc/types.d.ts";
 
 /** Stored as kind `module_entry` in datastore. */


### PR DESCRIPTION
This PR:

- Adds a dynamic component called `ContentMeta` which provides better management and information related to meta data associated with a page.  While it does not yet include images, it provides more meaningful meta information for cards and other expansions across the site.
- Alters the `isHTML` check to serve bots, like the Google Crawler and other bots and crawlers the HTML content for `std` and third party modules.  Currently, we serve the raw content, which is not what we really want indexed.
