### PR TITLE
feat: module symbol linking in docs

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -63,12 +63,13 @@ export function RawCodeBlock({
 
   const tokens = normalizeTokens(Prism.tokenize(code, grammar));
 
-  return <pre
-    className={tw`text-sm flex ${extraClassName ?? ""}` +
-      ` gfm-highlight highlight-source-${newLang}`}
-    data-color-mode="light"
-    data-light-theme="light"
-  >
+  return (
+    <pre
+      className={tw`text-sm flex ${extraClassName ?? ""}` +
+        ` gfm-highlight highlight-source-${newLang}`}
+      data-color-mode="light"
+      data-light-theme="light"
+    >
       {enableLineRef &&
         (
           <div className={codeDivClasses}>
@@ -132,7 +133,8 @@ export function RawCodeBlock({
           );
         })}
       </div>
-  </pre>;
+    </pre>
+  );
 }
 
 export function CodeBlock(props: CodeBlockProps) {

--- a/components/DocView.tsx
+++ b/components/DocView.tsx
@@ -4,6 +4,7 @@
 /** @jsxFrag Fragment */
 import { Fragment, h } from "preact";
 import { tw } from "@twind";
+import { setNav } from "@/util/doc_utils.ts";
 import { type CommonProps, getModulePath } from "@/util/registry_utils.ts";
 import { dirname } from "$std/path/mod.ts";
 import { ModuleDoc } from "$doc_components/doc/module_doc.tsx";
@@ -30,6 +31,9 @@ export function DocView({
     : undefined;
   const baseUrl = new URL(url);
   baseUrl.pathname = getModulePath(name, version);
+  if (data.kind === "module" || data.kind === "symbol") {
+    setNav(path, data.nav);
+  }
 
   return (
     <SidePanelPage

--- a/components/DocView.tsx
+++ b/components/DocView.tsx
@@ -2,9 +2,9 @@
 
 /** @jsx h */
 /** @jsxFrag Fragment */
-import { Fragment, h } from "preact";
+import { h } from "preact";
 import { tw } from "@twind";
-import { setNav } from "@/util/doc_utils.ts";
+import { setSymbols } from "@/util/doc_utils.ts";
 import { type CommonProps, getModulePath } from "@/util/registry_utils.ts";
 import { dirname } from "$std/path/mod.ts";
 import { ModuleDoc } from "$doc_components/doc/module_doc.tsx";
@@ -31,9 +31,11 @@ export function DocView({
     : undefined;
   const baseUrl = new URL(url);
   baseUrl.pathname = getModulePath(name, version);
-  if (data.kind === "module" || data.kind === "symbol") {
-    setNav(path, data.nav);
-  }
+  setSymbols(
+    (data.kind === "module" || data.kind === "symbol")
+      ? data.symbols
+      : undefined,
+  );
 
   return (
     <SidePanelPage

--- a/main.ts
+++ b/main.ts
@@ -12,6 +12,7 @@ import { ServerContext } from "$fresh/server.ts";
 import { Fragment, h } from "preact";
 import { serve } from "$std/http/server.ts";
 import { router } from "$router";
+import { lookupSymbol } from "./util/doc_utils.ts";
 import { withLog } from "./util/ga_utils.ts";
 import { setup } from "$doc_components/services.ts";
 
@@ -31,11 +32,11 @@ await setup({
     }
   },
   lookupHref(
-    _current: URL,
-    _namespace: string | undefined,
-    _symbol: string,
+    current: URL,
+    namespace: string | undefined,
+    symbol: string,
   ): string | undefined {
-    return undefined;
+    return lookupSymbol(current, namespace, symbol);
   },
   resolveSourceHref(url, line) {
     if (!url.startsWith("https://deno.land")) {

--- a/util/doc_utils.ts
+++ b/util/doc_utils.ts
@@ -1,0 +1,24 @@
+// Copyright 2022 the Deno authors. All rights reserved. MIT license.
+
+import { DocPageNavItem } from "./registry_utils.ts";
+
+let currentSymbols: string[] | undefined;
+
+export function setNav(path: string, nav: DocPageNavItem[]) {
+  currentSymbols = undefined;
+  for (const item of nav) {
+    if (item.path === path && item.kind === "module") {
+      currentSymbols = item.items.flatMap(({ name }) => name ? [name] : []);
+    }
+  }
+}
+
+export function lookupSymbol(
+  current: URL,
+  _namespace: string | undefined,
+  symbol: string,
+): string | undefined {
+  if (currentSymbols?.includes(symbol)) {
+    return `${current.pathname}?s=${symbol}`;
+  }
+}

--- a/util/doc_utils.ts
+++ b/util/doc_utils.ts
@@ -1,24 +1,54 @@
 // Copyright 2022 the Deno authors. All rights reserved. MIT license.
 
-import { DocPageNavItem } from "./registry_utils.ts";
+import { type SymbolIndexItem } from "./registry_utils.ts";
 
-let currentSymbols: string[] | undefined;
+const currentSymbols = new Set<string>();
+const currentImports = new Map<string, string>();
 
-export function setNav(path: string, nav: DocPageNavItem[]) {
-  currentSymbols = undefined;
-  for (const item of nav) {
-    if (item.path === path && item.kind === "module") {
-      currentSymbols = item.items.flatMap(({ name }) => name ? [name] : []);
+/** Called to set/clear the current symbol information, so when symbol lookups
+ * occur, they have the correct information to resolve the link. */
+export function setSymbols(symbols?: SymbolIndexItem[]) {
+  currentSymbols.clear();
+  currentImports.clear();
+  if (symbols) {
+    for (const { name, declarationKind, kind, filename } of symbols) {
+      if (declarationKind === "export") {
+        currentSymbols.add(name);
+      } else if (kind === "import") {
+        currentImports.set(name, filename);
+      }
     }
   }
 }
 
+/** Provided the current URL, current namespace, and symbol, attempt to resolve
+ * a link to the symbol. */
 export function lookupSymbol(
   current: URL,
-  _namespace: string | undefined,
+  namespace: string | undefined,
   symbol: string,
 ): string | undefined {
-  if (currentSymbols?.includes(symbol)) {
+  if (!currentSymbols.size) {
+    return undefined;
+  }
+  if (namespace) {
+    const parts = namespace.split(".");
+    while (parts.length) {
+      const name = [...parts, symbol].join(".");
+      if (currentSymbols.has(name)) {
+        return `${current.pathname}?s=${name}`;
+      }
+      parts.pop();
+    }
+  }
+  if (currentSymbols.has(symbol)) {
     return `${current.pathname}?s=${symbol}`;
+  }
+  if (currentImports.has(symbol)) {
+    const src = currentImports.get(symbol)!;
+    if (src.startsWith("https://deno.land/")) {
+      const srcURL = new URL(src);
+      return `${srcURL.pathname}?s=${symbol}`;
+    }
   }
 }

--- a/util/doc_utils.ts
+++ b/util/doc_utils.ts
@@ -36,19 +36,29 @@ export function lookupSymbol(
     while (parts.length) {
       const name = [...parts, symbol].join(".");
       if (currentSymbols.has(name)) {
-        return `${current.pathname}?s=${name}`;
+        const target = new URL(current);
+        target.searchParams.set("s", name);
+        return target.href;
       }
       parts.pop();
     }
   }
   if (currentSymbols.has(symbol)) {
-    return `${current.pathname}?s=${symbol}`;
+    const target = new URL(current);
+    target.searchParams.set("s", symbol);
+    return target.href;
   }
   if (currentImports.has(symbol)) {
     const src = currentImports.get(symbol)!;
+    const srcURL = new URL(src);
     if (src.startsWith("https://deno.land/")) {
-      const srcURL = new URL(src);
-      return `${srcURL.pathname}?s=${symbol}`;
+      srcURL.searchParams.set("s", symbol);
+      return srcURL.href;
+    } else {
+      // other sources, we will attempt to send them to docland for
+      // documentation
+      srcURL.pathname += `/~/${symbol}`;
+      return `https://doc.deno.land/${srcURL.toString()}`;
     }
   }
 }

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -496,17 +496,28 @@ interface DocPageModuleItem {
 
 export type DocPageNavItem = DocPageModuleItem | DocPageDirItem;
 
+type DeclarationKind = "private" | "export" | "declare";
+
+export interface SymbolIndexItem {
+  name: string;
+  kind: DocNodeKind;
+  declarationKind: DeclarationKind;
+  filename: string;
+}
+
 export interface DocPageSymbol extends PageBase {
   kind: "symbol";
   nav: DocPageNavItem[];
   name: string;
   docNodes: DocNode[];
+  symbols: SymbolIndexItem[];
 }
 
 export interface DocPageModule extends PageBase {
   kind: "module";
   nav: DocPageNavItem[];
   docNodes: DocNode[];
+  symbols: SymbolIndexItem[];
 }
 
 export interface DocPageIndex extends PageBase {


### PR DESCRIPTION
This PR introduces module level symbol linking.  Check an example here: https://dotland-rgfb0y453my0.deno.dev/x/oak@v11.1.0/application.ts?s=Application where you can see many of the symbols referenced in the API are clickable.

The only thing I am not sure about is that the linked version of the symbol is _black_ versus _blue_, but that is currently what doc components renders.  @crowlKats thoughts?