### PR TITLE
feat: global symbol linking in docs

### DIFF
--- a/components/DocView.tsx
+++ b/components/DocView.tsx
@@ -4,7 +4,6 @@
 /** @jsxFrag Fragment */
 import { h } from "preact";
 import { tw } from "@twind";
-import { setSymbols } from "@/util/doc_utils.ts";
 import { type CommonProps, getModulePath } from "@/util/registry_utils.ts";
 import { dirname } from "$std/path/mod.ts";
 import { ModuleDoc } from "$doc_components/doc/module_doc.tsx";
@@ -31,11 +30,6 @@ export function DocView({
     : undefined;
   const baseUrl = new URL(url);
   baseUrl.pathname = getModulePath(name, version);
-  setSymbols(
-    (data.kind === "module" || data.kind === "symbol")
-      ? data.symbols
-      : undefined,
-  );
 
   return (
     <SidePanelPage

--- a/routes/api.tsx
+++ b/routes/api.tsx
@@ -10,6 +10,7 @@ import { ContentMeta } from "@/components/ContentMeta.tsx";
 import { Header } from "@/components/Header.tsx";
 import { Footer } from "@/components/Footer.tsx";
 import { ManualOrAPI, SidePanelPage } from "@/components/SidePanelPage.tsx";
+import { setSymbols } from "@/util/doc_utils.ts";
 import { versions } from "@/util/manual_utils.ts";
 import VersionSelect from "@/islands/VersionSelect.tsx";
 import {
@@ -154,6 +155,7 @@ export const handler: Handlers<LibDocPage> = {
 
     const res = await fetch(resURL);
     const data = await res.json();
+    await setSymbols();
 
     return render!(data);
   },

--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -8,6 +8,7 @@ import { tw } from "@twind";
 import twas from "$twas";
 import { emojify } from "$emoji";
 import { accepts } from "$oak_commons";
+import { setSymbols } from "@/util/doc_utils.ts";
 import {
   type DocPage,
   type DocPageIndex,
@@ -224,7 +225,12 @@ export const handler: Handlers<PageData> = {
       );
     }
 
-    return render!({ data });
+    await setSymbols(
+      (data.data.kind === "module" || data.data.kind === "symbol")
+        ? data.data.symbols
+        : undefined,
+    );
+    return render({ data });
   },
 };
 

--- a/util/doc_utils.ts
+++ b/util/doc_utils.ts
@@ -2,12 +2,47 @@
 
 import { type SymbolIndexItem } from "./registry_utils.ts";
 
+interface GlobalSymbolItem {
+  name: string;
+  library: "esnext" | "deno";
+  unstable?: boolean;
+}
+
+const GLOBAL_SYMBOLS_ENDPOINT = "https://apiland.deno.dev/v2/symbols/global";
+const GLOBAL_SYMBOLS_INIT = { headers: { "accept": "application/json" } };
+
 const currentSymbols = new Set<string>();
 const currentImports = new Map<string, string>();
+const globalSymbols = new Map<string, "esnext" | "deno" | "deno-unstable">();
 
 /** Called to set/clear the current symbol information, so when symbol lookups
  * occur, they have the correct information to resolve the link. */
-export function setSymbols(symbols?: SymbolIndexItem[]) {
+export async function setSymbols(symbols?: SymbolIndexItem[]): Promise<void> {
+  if (!globalSymbols.size) {
+    try {
+      const res = await fetch(GLOBAL_SYMBOLS_ENDPOINT, GLOBAL_SYMBOLS_INIT);
+      if (res.status === 200) {
+        const globalSymbolItems: GlobalSymbolItem[] = await res.json();
+        for (const { name, library, unstable } of globalSymbolItems) {
+          globalSymbols.set(
+            name,
+            library === "esnext"
+              ? "esnext"
+              : unstable
+              ? "deno-unstable"
+              : "deno",
+          );
+        }
+      } else {
+        throw new Error(
+          `Unexpected fetch response: ${res.status} ${res.statusText}`,
+        );
+      }
+    } catch (e) {
+      console.error(e);
+      globalSymbols.set("__failed__", "deno");
+    }
+  }
   currentSymbols.clear();
   currentImports.clear();
   if (symbols) {
@@ -21,6 +56,20 @@ export function setSymbols(symbols?: SymbolIndexItem[]) {
   }
 }
 
+function globalSymbolHref(current: URL, symbol: string) {
+  const lib = globalSymbols.get(symbol)!;
+  if (lib !== "esnext") {
+    const target = new URL(current);
+    target.pathname = "/api";
+    target.search = "";
+    target.searchParams.set("s", symbol);
+    if (lib === "deno-unstable") {
+      target.searchParams.set("unstable", "");
+    }
+    return target.href;
+  }
+}
+
 /** Provided the current URL, current namespace, and symbol, attempt to resolve
  * a link to the symbol. */
 export function lookupSymbol(
@@ -28,17 +77,20 @@ export function lookupSymbol(
   namespace: string | undefined,
   symbol: string,
 ): string | undefined {
-  if (!currentSymbols.size) {
-    return undefined;
-  }
   if (namespace) {
     const parts = namespace.split(".");
     while (parts.length) {
       const name = [...parts, symbol].join(".");
-      if (currentSymbols.has(name)) {
-        const target = new URL(current);
-        target.searchParams.set("s", name);
-        return target.href;
+      if (currentSymbols.size) {
+        if (currentSymbols.has(name)) {
+          const target = new URL(current);
+          target.searchParams.set("s", name);
+          return target.href;
+        }
+      } else {
+        if (globalSymbols.has(name)) {
+          return globalSymbolHref(current, name);
+        }
       }
       parts.pop();
     }
@@ -60,5 +112,8 @@ export function lookupSymbol(
       srcURL.pathname += `/~/${symbol}`;
       return `https://doc.deno.land/${srcURL.toString()}`;
     }
+  }
+  if (globalSymbols.has(symbol)) {
+    return globalSymbolHref(current, symbol);
   }
 }


### PR DESCRIPTION
This PR enable global symbol linking.  This means that both `/api` doc pages, but also any third party modules/std library modules that use types out of the global scopes can now link to them.

The only thing missing is that we have global symbols that are part of "ESNext" as well as convenience types like `Omit` that we have no pages to link to yet.  For the esnext symbols, we will try to link to MDN in the future.