### PR TITLE
feat: add canonical links for apis and modules

### DIFF
--- a/components/ContentMeta.tsx
+++ b/components/ContentMeta.tsx
@@ -49,6 +49,7 @@ export function ContentMeta(
   {
     title = DEFAULT_TITLE,
     description,
+    canonical,
     creator,
     keywords = DEFAULT_KEYWORDS,
     ogType = "website",
@@ -58,6 +59,7 @@ export function ContentMeta(
   }: {
     title: string;
     description?: string;
+    canonical?: URL;
     creator?: string;
     keywords?: string[];
     ogType?: OgType;
@@ -77,6 +79,8 @@ export function ContentMeta(
       <title>{title}</title>
       <meta name="twitter:title" content={title} />
       <meta property="og:title" content={title} />
+
+      {canonical && <link rel="canonical" href={canonical.toString()} />}
 
       {description && (
         <>

--- a/routes/api.tsx
+++ b/routes/api.tsx
@@ -14,6 +14,7 @@ import { setSymbols } from "@/util/doc_utils.ts";
 import { versions } from "@/util/manual_utils.ts";
 import VersionSelect from "@/islands/VersionSelect.tsx";
 import {
+  getCanonicalUrl,
   getLibDocPageDescription,
   type LibDocPage,
 } from "@/util/registry_utils.ts";
@@ -30,6 +31,8 @@ export default function API(
     "",
   ]];
 
+  const canonical = getCanonicalUrl(url, data.latest_version);
+
   return (
     <>
       <ContentMeta
@@ -37,6 +40,7 @@ export default function API(
           ? `${data.name} | Runtime APIs`
           : "Runtime APIs"}
         description={getLibDocPageDescription(data)}
+        canonical={canonical}
         creator="@deno_land"
         ogImage="api"
         keywords={["deno", "api", "built-in", "typescript", "javascript"]}

--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -16,6 +16,7 @@ import {
   type DocPageSymbol,
   extractAltLineNumberReference,
   fetchSource,
+  getCanonicalUrl,
   getDocAsDescription,
   getModulePath,
   getRawFile,
@@ -285,11 +286,17 @@ export default function Registry(
   const path = maybePath ? "/" + maybePath : "";
   const isStd = name === "std";
 
+  let canonical: URL | undefined;
+  if (data && "latest_version" in data.data) {
+    canonical = getCanonicalUrl(url, data.data.latest_version);
+  }
+
   return (
     <>
       <ContentMeta
         title={getTitle(name, version, data)}
         description={getDescription(data)}
+        canonical={canonical}
         ogImage={isStd ? "std" : "modules"}
         keywords={["deno", "third party", "module", name]}
       />

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -387,6 +387,17 @@ function docAsDescription(doc: string) {
   return doc.split("\n\n")[0].slice(0, 199);
 }
 
+export function getCanonicalUrl(url: URL, latestVersion: string) {
+  const canonical = new URL(url);
+  canonical.host = "deno.land:80";
+  canonical.protocol = "https:";
+  canonical.pathname = canonical.pathname.replace(
+    /@[^/]+/,
+    `@${latestVersion}`,
+  );
+  return canonical;
+}
+
 /** For a LibDocPage, attempt to extract a description to be used with the
  * content meta for the page. */
 export function getLibDocPageDescription(data: LibDocPage): string | undefined {


### PR DESCRIPTION
This PR add canonical links in the header for `/api`, `/std` and `/x` pages.  This will improve the crawling of search engines of `deno.land` to help ensure that the search engines are indexing the latest versions of pages and documentation and preferring those in the search results.