### PR TITLE
Add `Ctrl+K` to search bar

### DIFF
--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -261,7 +261,7 @@ export default function GlobalSearch({ denoVersion }: { denoVersion: string }) {
             Search...
           </div>
           <div class={tw`mx-4`}>
-            ⌘K
+            Ctrl+K / ⌘K
           </div>
         </div>
       </button>


### PR DESCRIPTION
This is more of a thing for people who don't use/aren't familiar with the Mac keyboard layout. 
 
Here's what it looks like, now:
![image](https://user-images.githubusercontent.com/79608594/196009528-56606e86-6347-408f-b7e6-8cc631bc5071.png)
