### PR TITLE
fix: better handling of query params

### DIFF
--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -157,6 +157,8 @@ export const handler: Handlers<PageData> = {
 
     const queryId = url.searchParams.get("qid");
     const position = url.searchParams.get("pos");
+    url.searchParams.delete("qid");
+    url.searchParams.delete("pos");
     if (queryId && position && remoteAddr.transport === "tcp") {
       ssrSearchClick(
         await getUserToken(req.headers, remoteAddr.hostname),

--- a/util/registry_utils.ts
+++ b/util/registry_utils.ts
@@ -387,6 +387,9 @@ function docAsDescription(doc: string) {
   return doc.split("\n\n")[0].slice(0, 199);
 }
 
+/** Search parameters which are considered part of a canonical URL.  */
+const CANONICAL_SEARCH_PARAMS = ["s", "source", "doc", "unstable"];
+
 export function getCanonicalUrl(url: URL, latestVersion: string) {
   const canonical = new URL(url);
   canonical.hostname = "deno.land";
@@ -396,6 +399,12 @@ export function getCanonicalUrl(url: URL, latestVersion: string) {
     /@[^/]+/,
     `@${latestVersion}`,
   );
+  canonical.search = "";
+  for (const param of CANONICAL_SEARCH_PARAMS) {
+    if (url.searchParams.has(param)) {
+      canonical.searchParams.set(param, url.searchParams.get(param)!);
+    }
+  }
   return canonical;
 }
 


### PR DESCRIPTION
There are situations where we are leaking query params on redirects and canonical URLs.  This helps ensure they are properly set.