### PR TITLE
a11y: fix std lib version selector link contrast

### DIFF
--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -680,7 +680,9 @@ function InfoView(
                 <li class="odd:(bg-ultralight rounded-md)">
                   <a
                     class={`flex px-5 py-2 link ${
-                      listVersion === version ? "font-bold" : "font-medium"
+                      listVersion === version
+                        ? "text-primary font-bold"
+                        : "text-default font-normal"
                     }`}
                     href={getModulePath(name, listVersion)}
                   >


### PR DESCRIPTION
Addresses #2478 by overriding default link colors with `primary` for selected version and `black` for rest consistent with manual route, so that they're contrasting enough

<img width="200" alt="Screenshot 2022-11-02 at 14 09 56" src="https://user-images.githubusercontent.com/3174355/199603789-80bf89b7-4a8c-41ba-a125-68ead7b9c765.png"><img width="200" alt="Screenshot 2022-11-02 at 14 10 11" src="https://user-images.githubusercontent.com/3174355/199603797-ca197489-e48d-4f25-8957-301c93eeb74c.png">
