### PR TITLE
Improve the experience of the expand button in the manual

### DIFF
--- a/routes/manual.tsx
+++ b/routes/manual.tsx
@@ -201,7 +201,7 @@ function ToCEntry({
           aria-label={`open section ${name}`}
           onKeyDown="if (event.code === 'Space' || event.code === 'Enter') { this.parentElement.click(); event.preventDefault(); }"
           tabindex={0}
-          class={"h-2.5 w-auto cursor-pointer " +
+          class={"h-2.5 w-auto cursor-pointer outline-none select-none " +
             (hasChildren ? "" : "invisible")}
         />
         <a href={`/manual@${version}/${slug}`}>


### PR DESCRIPTION
`outline-none` is to remove the border when in focus.
<img width="181" alt="image" src="https://user-images.githubusercontent.com/24505451/201015722-b5364881-d574-4c25-bf89-710bb2e30657.png">

`select-none` is to prevent the text on the right side from being selected when the user double-clicks the icon. PS: when the list is expanded and then clicked again to close it, it is considered a double-click.