### PR TITLE
fix(x/module): better deno icon size

### DIFF
--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -582,7 +582,7 @@ function InfoView(
   if (data.config) {
     attributes.push(
       <div class="flex items-center gap-1.5">
-        <Icons.Logo />
+        <Icons.Logo class="w-4 h-4" />
         <span class="text-gray-600 font-medium leading-none">
           Includes Deno configuration
         </span>


### PR DESCRIPTION
In 3rd party module page, `Includes Deno configuration` status icon looks too huge now. This PR tries to fix it.

BEFORE
<img width="353" alt="スクリーンショット 2022-11-16 17 10 13" src="https://user-images.githubusercontent.com/613956/202124058-213b91f0-190b-4726-a998-25081662ec46.png">

AFTER
<img width="411" alt="スクリーンショット 2022-11-16 17 08 54" src="https://user-images.githubusercontent.com/613956/202124086-f6e705d8-aa67-4384-a89f-9c0af4b82e41.png">
