### PR TITLE
Display correct search shortcut on Windows/Linux

### DIFF
--- a/islands/GlobalSearch.tsx
+++ b/islands/GlobalSearch.tsx
@@ -145,6 +145,8 @@ export default function GlobalSearch({ denoVersion }: { denoVersion: string }) {
   const searchTimeoutId = useRef<number | null>(null);
   const [loading, setLoading] = useState(false);
 
+  const [macintosh, setMacintosh] = useState(true);
+
   useEffect(() => {
     const keyboardHandler = (e: KeyboardEvent) => {
       if (e.key === "Escape" && showModal) setShowModal(false);
@@ -245,6 +247,10 @@ export default function GlobalSearch({ denoVersion }: { denoVersion: string }) {
     }
   }, [showModal]);
 
+  useEffect(() => {
+    setMacintosh(window.navigator.platform.includes("Mac"));
+  }, []);
+
   return (
     <>
       <button
@@ -258,7 +264,7 @@ export default function GlobalSearch({ denoVersion }: { denoVersion: string }) {
             Search...
           </div>
           <div class="mx-4">
-            ⌘K
+            {macintosh ? <div>⌘ + k</div> : <div>Ctrl + k</div>}
           </div>
         </div>
       </button>


### PR DESCRIPTION
I noticed that the deno page shows `⌘ + k` for all browsers.

This PR adds a check that displays either `⌘ + k` or  `Ctrl + k` based on the browser navigator platform.

Search bar displayed on Mac
![image](https://user-images.githubusercontent.com/14146321/203314535-36b51c84-f75c-4b9b-a454-29fe899f6eb9.png)


Search bar displayed on Windows/Linux
![image](https://user-images.githubusercontent.com/14146321/203314455-0b0f6341-00e7-4e38-bc6c-6f287f0daaed.png)
 