### PR TITLE
fix: Remove redundant icons

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -183,21 +183,6 @@ export function Header({ selected, manual }: {
             </div>
 
             <GlobalSearch denoVersion={versions.cli[0]} />
-
-            <a
-              href="https://github.com/denoland/deno"
-              class="my-auto hidden lg:block"
-            >
-              <span class="sr-only">GitHub</span>
-              <Icons.GitHub class="h-5 w-auto text-gray-600 hover:text-default" />
-            </a>
-            <a
-              href="https://discord.gg/deno"
-              class="my-auto hidden lg:block"
-            >
-              <span class="sr-only">Discord</span>
-              <Icons.Discord class="h-5 w-auto text-gray-600 hover:text-default" />
-            </a>
           </div>
         </nav>
       </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -35,7 +35,7 @@ const entries: Array<HrefEntry | ChildrenEntry> = [
   },
   { href: "https://deno.com/deploy", content: "Deploy" },
   {
-    content: "Communities",
+    content: "Community",
     children: [
       {
         href: "https://discord.gg/deno",


### PR DESCRIPTION
Note links in community drop down

Before
<img width="1440" alt="Screen Shot 2022-12-01 at 9 24 00 PM" src="https://user-images.githubusercontent.com/80/205220894-355b14c6-b9fb-438a-9625-402a7624c4a6.png">


After
<img width="1440" alt="Screen Shot 2022-12-01 at 9 23 43 PM" src="https://user-images.githubusercontent.com/80/205220866-4010798d-a054-45a4-8b68-910c36525180.png">
