### PR TITLE
add link to mastodon for verification

### DIFF
--- a/components/ContentMeta.tsx
+++ b/components/ContentMeta.tsx
@@ -72,6 +72,7 @@ export function ContentMeta(
     <Head>
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@deno_land" />
+      <link rel="me" href="https://fosstodon.org/@deno_land" />
 
       <title>{title}</title>
       <meta name="twitter:title" content={title} />


### PR DESCRIPTION
Following instructions here: https://docs.joinmastodon.org/user/profile/#verification

Basically to get a verified check on Mastodon, we just need to place a link to our Mastodon account somewhere in the deno.land, and link to deno.land from the Mastodon bio.