### PR TITLE
fix: prevent wrapping and truncate overflowing text

### DIFF
--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -588,7 +588,7 @@ function Breadcrumbs({
   }
 
   return (
-    <p class="text-xl leading-6 font-bold text-gray-400 space-x-1 children:inline-block">
+    <p class="text-xl leading-6 font-bold text-gray-400 space-x-1 truncate">
       {out.map(([seg, url, separator], i) => {
         if (view === "source") {
           url += "?source";


### PR DESCRIPTION
#2632 Removal of "children:inline-block" class which causes to wrap