### PR TITLE
fix: revert "update gfm (#2644)"

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -15,7 +15,7 @@
     "$twas": "https://esm.sh/twas@2.1.2",
     "$emoji": "https://deno.land/x/emoji@0.1.2/mod.ts",
     "$std/": "https://deno.land/std@0.170.0/",
-    "$gfm": "https://deno.land/x/gfm@0.1.27/mod.ts",
+    "$gfm": "https://deno.land/x/gfm@0.1.22/mod.ts",
     "$tiny-version-compare": "https://esm.sh/tiny-version-compare@3.0.1",
     "$fuse/": "https://deno.land/x/fuse@v6.4.1/dist/",
     "$he": "https://esm.sh/he@1.2.0?pin=v87",


### PR DESCRIPTION
#2644 seems to have broken the internal links in the manual page. This PR reverts it for now.