### PR TITLE
fix: properly handle resolveSourceHref search params

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -39,11 +39,16 @@ await setup({
   ): string | undefined {
     return lookupSymbol(current, namespace, symbol);
   },
-  resolveSourceHref(url, line) {
-    if (!url.startsWith("https://deno.land")) {
-      return url;
+  resolveSourceHref(currentUrl, line) {
+    const url = new URL(currentUrl);
+    if (url.origin !== "https://deno.land") {
+      return currentUrl;
     }
-    return line ? `${url}?source#L${line}` : `${url}?source`;
+    url.search = "?source";
+    if (line != null) {
+      url.hash = `#L${line}`;
+    }
+    return url.href;
   },
 });
 

--- a/tests/handler_test.ts
+++ b/tests/handler_test.ts
@@ -30,8 +30,13 @@ await setup({
   ): string | undefined {
     return undefined;
   },
-  resolveSourceHref(url, line) {
-    return line ? `${url}?source#L${line}` : `${url}?source`;
+  resolveSourceHref(currentUrl, line) {
+    const url = new URL(currentUrl);
+    url.search = "?source";
+    if (line != null) {
+      url.hash = `#L${line}`;
+    }
+    return url.href;
   },
 });
 


### PR DESCRIPTION
The bug I had:

1. Visit https://deno.land/x/deno@v1.30.0/cli?doc
2. Click the icon seems like 'view source'
3. It's exactly same page but different url: https://deno.land/x/deno@v1.30.0/cli?doc?source
4. https://deno.land/x/deno@v1.30.0/cli?doc?source?source
5. https://deno.land/x/deno@v1.30.0/cli?doc?source?source?source
6. https://deno.land/x/deno@v1.30.0/cli?doc?source?source?source?source

I'm not sure this fixes the bug, btw.