### PR TITLE
fix: Give better feedback validating the module name

### DIFF
--- a/utils/registry_utils.ts
+++ b/utils/registry_utils.ts
@@ -3,6 +3,7 @@
 import type { DocNode } from "deno_doc/types";
 import type { LibDocPage, ModuleEntry } from "$apiland_types";
 
+const NAME_REGEX = /^[a-z0-9_]{3,40}$/;
 export const CDN_ENDPOINT = "https://cdn.deno.land/";
 
 export interface CommonProps<T> {
@@ -356,5 +357,18 @@ export function getDocAsDescription(
     } else if (docNode.jsDoc?.doc) {
       return docAsDescription(docNode.jsDoc.doc);
     }
+  }
+}
+
+export async function validateModuleName(
+  name: string,
+  controller: AbortController,
+) {
+  if (name === "" || !NAME_REGEX.test(name)) {
+    return "invalid";
+  } else {
+    return await getVersionList(name, controller.signal)
+      .then((e) => !e)
+      .catch(() => false);
   }
 }

--- a/utils/registry_utils_test.ts
+++ b/utils/registry_utils_test.ts
@@ -5,6 +5,7 @@ import {
   fileTypeFromURL,
   getSourceURL,
   getVersionList,
+  validateModuleName,
 } from "./registry_utils.ts";
 import { assert, assertEquals } from "$std/testing/asserts.ts";
 
@@ -111,5 +112,28 @@ Deno.test("extractLinkUrl", () => {
   assertEquals(
     extractLinkUrl(`"./foo.ts"`, "https://deno.land/README.md"),
     undefined,
+  );
+});
+
+Deno.test("validateModuleName", async () => {
+  const controller = new AbortController();
+  controller.abort();
+
+  assertEquals(
+    await validateModuleName("hello-world", controller),
+    "invalid",
+  );
+
+  assertEquals(
+    await validateModuleName("hello", controller),
+    false,
+  );
+
+  assertEquals(
+    await validateModuleName(
+      "defuniq" + parseInt(`${Math.random() * 1000}`),
+      new AbortController(),
+    ),
+    true,
   );
 });


### PR DESCRIPTION
This adds a distinction between a valid module name and a module name that has already been taken. It also clarifies what a valid module name is.

This addresses the confusion pointed in https://github.com/denoland/dotland/issues/2393.

https://user-images.githubusercontent.com/7757/218585985-e998b151-7f96-4046-a6b3-62bcc0a3aae1.mp4

