### PR TITLE
feat: add useful com redirects

### DIFF
--- a/routes/blog.ts
+++ b/routes/blog.ts
@@ -1,0 +1,7 @@
+import { type Handlers } from "$fresh/server.ts";
+
+export const handler: Handlers = {
+  GET() {
+    return Response.redirect("https://deno.com/blog", 302);
+  },
+};

--- a/routes/deploy.ts
+++ b/routes/deploy.ts
@@ -1,0 +1,7 @@
+import { type Handlers } from "$fresh/server.ts";
+
+export const handler: Handlers = {
+  GET() {
+    return Response.redirect("https://deno.com/deploy", 302);
+  },
+};

--- a/routes/subhosting.ts
+++ b/routes/subhosting.ts
@@ -1,0 +1,7 @@
+import { type Handlers } from "$fresh/server.ts";
+
+export const handler: Handlers = {
+  GET() {
+    return Response.redirect("https://deno.com/subhosting", 302);
+  },
+};


### PR DESCRIPTION
This is a simple change but would allow erroneous links (like https://deno.land/deploy instead of https://deno.com/deploy) to still convert correctly. These are the three paths that I think are probably often mistaken.