### PR TITLE
showcase: Add GitHub link to existing Neolace entry

### DIFF
--- a/data/showcase.json
+++ b/data/showcase.json
@@ -183,7 +183,8 @@
   {
     "image": "/images/showcase/neolace.png",
     "title": "Neolace",
-    "link": "https://www.neolace.com/"
+    "link": "https://www.neolace.com/",
+    "github": "neolace-dev/neolace"
   },
   {
     "image": "/images/showcase/socialcards.png",


### PR DESCRIPTION
Our software platform Neolace is featured in the Deno showcase, and we have recently made the GitHub/source public, so I wanted to add the GitHub link too.

https://github.com/neolace-dev/neolace

Thanks!