### PR TITLE
fix(x/std): make server-timing async-safe

### DIFF
--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -285,19 +285,13 @@ async function handlerRaw(
     });
   }
 
-  performance.mark("fetchSourceStart");
+  const start = performance.now();
   const res = await fetchSource(name, version, path);
-  performance.mark("fetchSourceEnd");
-
-  const fetchSourcePerf = performance.measure(
-    "fetchSource",
-    "fetchSourceStart",
-    "fetchSourceEnd",
-  );
+  const end = performance.now();
 
   res.headers.set(
     "Server-Timing",
-    `fetchSource;dur=${fetchSourcePerf.duration.toPrecision(3)}`,
+    `fetchSource;dur=${(end - start).toPrecision(3)}`,
   );
 
   return res;


### PR DESCRIPTION
`performance.mark` mark names are in a global namespace and therefore is not safe to use across `await`.