### PR TITLE
chore(x/std): append server-timing instead of set

### DIFF
--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/utils/search_insights_utils.ts";
 import { Footer } from "$doc_components/footer.tsx";
 import { processProperty } from "$doc_components/doc/utils.ts";
+import { match } from "https://deno.land/x/path_to_regexp@v6.2.0/index.ts";
 
 type Views = "doc" | "source" | "info";
 type Params = {
@@ -289,9 +290,9 @@ async function handlerRaw(
   const res = await fetchSource(name, version, path);
   const end = performance.now();
 
-  res.headers.set(
+  res.headers.append(
     "Server-Timing",
-    `fetchSource;dur=${(end - start).toPrecision(3)}`,
+    `fetchSource;dur=${Math.ceil(end - start)}`,
   );
 
   return res;


### PR DESCRIPTION
Cloudfront now sends us server-timing header and we want to append our
values to it instead of overwriting it.

