### PR TITLE
Use marked-smartypants to replace punctuation in markdown content with smart punctuation

### DIFF
--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -1,6 +1,11 @@
 // Copyright 2022-2023 the Deno authors. All rights reserved. MIT license.
 
-import { render } from "$gfm";
+import { Marked, render } from "$gfm";
+import { markedSmartypants } from "$marked-smartypants";
+import { mangle } from "$marked-mangle";
+
+Marked.marked.use(markedSmartypants());
+Marked.marked.use(mangle());
 
 export function Markdown(
   { source, baseURL, mediaBaseURL }: {

--- a/import_map.json
+++ b/import_map.json
@@ -15,7 +15,7 @@
     "$twas": "https://esm.sh/twas@2.1.3",
     "$emoji": "https://deno.land/x/emoji@0.2.1/mod.ts",
     "$std/": "https://deno.land/std@0.177.0/",
-    "$gfm": "https://deno.land/x/gfm@0.1.30/mod.ts",
+    "$gfm": "../deno-gfm/mod.ts",
     "$fuse/": "https://deno.land/x/fuse@v6.4.1/dist/",
     "$he": "https://esm.sh/he@1.2.0",
     "$ga4": "https://raw.githubusercontent.com/denoland/ga4/04a1ce209116f158b5ef1658b957bdb109db68ed/mod.ts",
@@ -28,6 +28,8 @@
     "$canvas-confetti": "https://esm.sh/canvas-confetti@1.6.0",
     "$algolia": "https://esm.sh/algoliasearch@4.14.3",
     "$algolia/client-search": "https://esm.sh/@algolia/client-search@4.14.3",
-    "$algolia/requester-fetch": "https://esm.sh/@algolia/requester-fetch@4.14.3"
+    "$algolia/requester-fetch": "https://esm.sh/@algolia/requester-fetch@4.14.3",
+    "$marked-smartypants": "https://esm.sh/marked-smartypants@1.0.1",
+    "$marked-mangle": "https://esm.sh/marked-mangle@1.0.1"
   }
 }


### PR DESCRIPTION
Waiting on https://github.com/denoland/deno-gfm/pull/66.