### PR TITLE
ui: Use word-break on module description

### DIFF
--- a/routes/x/module.tsx
+++ b/routes/x/module.tsx
@@ -726,7 +726,7 @@ function InfoView(
 
               {data.description &&
                 (
-                  <div class="text-sm" title={data.description}>
+                  <div class="text-sm break-words" title={data.description}>
                     {data.description}
                   </div>
                 )}


### PR DESCRIPTION
Before:
<img width="543" alt="image" src="https://github.com/denoland/dotland/assets/1523305/2dde4359-c62d-4f8c-b959-ac36f635b9dd">

After:
<img width="543" alt="image" src="https://github.com/denoland/dotland/assets/1523305/87e46574-1e48-4e8d-a6fa-a2a7c4e934a9">
